### PR TITLE
Icons: preventpinning flag added

### DIFF
--- a/Projects/Compile.pas
+++ b/Projects/Compile.pas
@@ -5040,10 +5040,10 @@ const
     (Name: ParamCommonAfterInstall; Flags: []),
     (Name: ParamCommonMinVersion; Flags: []),
     (Name: ParamCommonOnlyBelowVersion; Flags: []));
-  Flags: array[0..8] of PChar = (
+  Flags: array[0..9] of PChar = (
     'uninsneveruninstall', 'runminimized', 'createonlyiffileexists',
     'useapppaths', 'closeonexit', 'dontcloseonexit', 'runmaximized',
-    'foldershortcut', 'excludefromshowinnewinstall');
+    'foldershortcut', 'excludefromshowinnewinstall', 'preventpinning');
 var
   Values: array[TParam] of TParamValue;
   NewIconEntry: PSetupIconEntry;
@@ -5075,6 +5075,7 @@ begin
           6: ShowCmd := SW_SHOWMAXIMIZED;
           7: Include(Options, ioFolderShortcut);
           8: Include(Options, ioExcludeFromShowInNewInstall);
+          9: Include(Options, ioPreventPinning);
         end;
 
       { Name }

--- a/Projects/Install.pas
+++ b/Projects/Install.pas
@@ -1728,7 +1728,8 @@ var
       WorkingDir, IconFilename: String; const IconIndex, ShowCmd: Integer;
       const NeverUninstall: Boolean; const CloseOnExit: TSetupIconCloseOnExit;
       const HotKey: Word; FolderShortcut: Boolean;
-      const AppUserModelID: String; const ExcludeFromShowInNewInstall: Boolean);
+      const AppUserModelID: String; const ExcludeFromShowInNewInstall: Boolean;
+      const PreventPinning: Boolean);
     var
       BeginsWithGroup: Boolean;
       LinkFilename, PifFilename, UrlFilename, DirFilename, ProbableFilename,
@@ -1782,7 +1783,8 @@ var
           environment-variable strings (e.g. %SystemRoot%\...) }
         ResultingFilename := CreateShellLink(LinkFilename, Description, Path,
           Parameters, WorkingDir, IconFilename, IconIndex, ShowCmd, HotKey,
-          FolderShortcut, AppUserModelID, ExcludeFromShowInNewInstall);
+          FolderShortcut, AppUserModelID, ExcludeFromShowInNewInstall,
+          PreventPinning);
         FolderShortcutCreated := FolderShortcut and DirExists(ResultingFilename);
 
         { If a .pif file was created, apply the "Close on exit" setting }
@@ -1876,7 +1878,8 @@ var
                 ExpandConst(IconFilename), IconIndex, ShowCmd,
                 ioUninsNeverUninstall in Options, CloseOnExit, HotKey,
                 ioFolderShortcut in Options, ExpandConst(AppUserModelID),
-                ioExcludeFromShowInNewInstall in Options);
+                ioExcludeFromShowInNewInstall in Options,
+                ioPreventPinning in Options);
             NotifyAfterInstallEntry(AfterInstall);
           end;
         end;

--- a/Projects/Struct.pas
+++ b/Projects/Struct.pas
@@ -268,7 +268,8 @@ type
     CloseOnExit: TSetupIconCloseOnExit;
     HotKey: Word;
     Options: set of (ioUninsNeverUninstall, ioCreateOnlyIfFileExists,
-      ioUseAppPaths, ioFolderShortcut, ioExcludeFromShowInNewInstall);
+      ioUseAppPaths, ioFolderShortcut, ioExcludeFromShowInNewInstall,
+      ioPreventPinning);
   end;
 const
   SetupIniEntryStrings = 10;


### PR DESCRIPTION
Adds preventpinning flag to the list of possible flags in the [Icons] section. It maps to the PKEY_AppUserModel_PreventPinning property.
