### PR TITLE
Set DCU and EXE/DLL output directory (batch files and dproj)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ compilesettings.bat
 C[Vv][Ss]
 .cvsignore
 Output
+__history
+/lib

--- a/Projects/Compil32.dproj
+++ b/Projects/Compil32.dproj
@@ -20,7 +20,10 @@
 			<Base>true</Base>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base)'!=''">
-			<DCC_DependencyCheckOutputName>Compil32.exe</DCC_DependencyCheckOutputName>
+			<DCC_StringChecks>off</DCC_StringChecks>
+			<DCC_DcuOutput>..\lib</DCC_DcuOutput>
+			<DCC_ExeOutput>..\files</DCC_ExeOutput>
+			<DCC_DependencyCheckOutputName>..\files\Compil32.exe</DCC_DependencyCheckOutputName>
 			<DCC_UnitSearchPath>..\components;..\components\unips\source;ispp;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
 			<DCC_UsePackage>VCL30;vclx30;VclSmp30;vcldb30;vcldbx30</DCC_UsePackage>
 			<DCC_ImageBase>00400000</DCC_ImageBase>
@@ -32,7 +35,6 @@
 			<DCC_F>false</DCC_F>
 			<DCC_S>false</DCC_S>
 			<DCC_N>true</DCC_N>
-			<DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
 			<DCC_WriteableConstants>true</DCC_WriteableConstants>
 			<DCC_E>false</DCC_E>
 			<DCC_AssertionsAtRuntime>false</DCC_AssertionsAtRuntime>

--- a/Projects/ISCmplr.dproj
+++ b/Projects/ISCmplr.dproj
@@ -20,7 +20,9 @@
 			<Base>true</Base>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base)'!=''">
-			<DCC_DependencyCheckOutputName>ISCmplr.dll</DCC_DependencyCheckOutputName>
+			<DCC_ExeOutput>..\files</DCC_ExeOutput>
+			<DCC_DcuOutput>..\lib</DCC_DcuOutput>
+			<DCC_DependencyCheckOutputName>..\files\ISCmplr.dll</DCC_DependencyCheckOutputName>
 			<DCC_UnitSearchPath>..\components;..\components\unips\source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
 			<DCC_UsePackage>VCL30;vclx30;VclSmp30;vcldb30;vcldbx30</DCC_UsePackage>
 			<DCC_ImageBase>00800000</DCC_ImageBase>
@@ -51,7 +53,9 @@
 			<DelphiCompile Include="ISCmplr.dpr">
 				<MainSource>MainSource</MainSource>
 			</DelphiCompile>
+			<DCCReference Include="SafeDLLPath.pas"/>
 			<DCCReference Include="CompInt.pas"/>
+			<DCCReference Include="CompPreprocInt.pas"/>
 			<DCCReference Include="Compile.pas"/>
 			<DCCReference Include="CompMsgs.pas"/>
 			<DCCReference Include="Struct.pas"/>

--- a/Projects/Setup.dproj
+++ b/Projects/Setup.dproj
@@ -20,10 +20,13 @@
 			<Base>true</Base>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base)'!=''">
-			<DCC_UnitSearchPath>..\components;..\components\rops\source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
-			<DCC_DependencyCheckOutputName>Setup.exe</DCC_DependencyCheckOutputName>
+			<DCC_StringChecks>off</DCC_StringChecks>
+			<DCC_DcuOutput>..\lib</DCC_DcuOutput>
+			<DCC_ExeOutput>..\files</DCC_ExeOutput>
+			<DCC_UnitSearchPath>..\components;..\components\rops\source;..\components\unips\source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+			<DCC_DependencyCheckOutputName>..\files\Setup.exe</DCC_DependencyCheckOutputName>
 			<DCC_ImageBase>00400000</DCC_ImageBase>
-			<DCC_Define>PS_MINIVCL;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS;$(DCC_Define)</DCC_Define>
+			<DCC_Define>PS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS;$(DCC_Define)</DCC_Define>
 			<DCC_Alignment>1</DCC_Alignment>
 			<DCC_UnitAlias>WinTypes=Windows;WinProcs=Windows;DbiTypes=BDE;DbiProcs=BDE;DbiErrs=BDE;$(DCC_UnitAlias)</DCC_UnitAlias>
 			<DCC_Platform>x86</DCC_Platform>
@@ -32,7 +35,6 @@
 			<DCC_N>true</DCC_N>
 			<DCC_S>false</DCC_S>
 			<DCC_F>false</DCC_F>
-			<DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
 			<DCC_AssertionsAtRuntime>false</DCC_AssertionsAtRuntime>
 			<DCC_E>false</DCC_E>
 		</PropertyGroup>

--- a/Projects/SetupLdr.dproj
+++ b/Projects/SetupLdr.dproj
@@ -20,7 +20,10 @@
 			<Base>true</Base>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base)'!=''">
-			<DCC_DependencyCheckOutputName>SetupLdr.exe</DCC_DependencyCheckOutputName>
+			<DCC_StringChecks>off</DCC_StringChecks>
+			<DCC_DcuOutput>..\lib</DCC_DcuOutput>
+			<DCC_ExeOutput>..\files</DCC_ExeOutput>
+			<DCC_DependencyCheckOutputName>..\files\SetupLdr.exe</DCC_DependencyCheckOutputName>
 			<DCC_ImageBase>00400000</DCC_ImageBase>
 			<DCC_WriteableConstants>true</DCC_WriteableConstants>
 			<DCC_UnitSearchPath>..\components;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
@@ -31,7 +34,6 @@
 			<DCC_N>true</DCC_N>
 			<DCC_S>false</DCC_S>
 			<DCC_F>false</DCC_F>
-			<DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
 			<DCC_AssertionsAtRuntime>false</DCC_AssertionsAtRuntime>
 			<DCC_E>false</DCC_E>
 		</PropertyGroup>

--- a/compile-unicode.bat
+++ b/compile-unicode.bat
@@ -27,9 +27,14 @@ if "%UNIROPSPATH%"=="" goto compilesettingserror
 
 rem -------------------------------------------------------------------------
 
+cd /d "%~dp0"
+
 rem  Compile each project separately because it seems Delphi
 rem  carries some settings (e.g. $APPTYPE) between projects
 rem  if multiple projects are specified on the command line.
+
+mkdir lib >NUL 2>NUL
+mkdir lib\ISPP >NUL 2>NUL
 
 cd Projects
 if errorlevel 1 goto exit
@@ -38,34 +43,41 @@ cd ISPP
 if errorlevel 1 goto failed
 
 echo - ISPPCC.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib" -E..\..\Files ISPPCC.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib" -E..\..\Files -N..\..\lib\ISPP ISPPCC.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - ISPP.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib" -E..\..\Files ISPP.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib" -E..\..\Files -N..\..\lib\ISPP ISPP.dpr
 if errorlevel 1 goto failed
+echo.
 
 cd ..
 
 echo - Compil32.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS Compil32.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS Compil32.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - ISCC.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS ISCC.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS ISCC.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - ISCmplr.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS ISCmplr.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS ISCmplr.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - SetupLdr.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components" -E..\Files SetupLdr.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components" -E..\Files -N..\lib SetupLdr.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - Setup.dpr
-"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS Setup.dpr
+"%DELPHI2009ROOT%\bin\dcc32.exe" --no-config --peflags:1 --string-checks:off -Q -B -H -W %1 -U"%DELPHI2009ROOT%\lib;..\Components;%UNIROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOINT64;PS_NOGRAPHCONST;PS_PANSICHAR;PS_NOINTERFACEGUIDBRACKETS Setup.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - Renaming files
 cd ..\Files

--- a/compile.bat
+++ b/compile.bat
@@ -9,6 +9,8 @@ rem  Batch file to compile all projects without Unicode support
 
 setlocal
 
+cd /d "%~dp0"
+
 if exist compilesettings.bat goto compilesettingsfound
 :compilesettingserror
 echo compilesettings.bat is missing or incomplete. It needs to be created
@@ -37,6 +39,9 @@ rem  Compile each project separately because it seems Delphi
 rem  carries some settings (e.g. $APPTYPE) between projects
 rem  if multiple projects are specified on the command line.
 
+mkdir lib >NUL 2>NUL
+mkdir lib\ISPP >NUL 2>NUL
+
 cd Projects
 if errorlevel 1 goto exit
 
@@ -44,34 +49,41 @@ cd ISPP
 if errorlevel 1 goto failed
 
 echo - ISPPCC.dpr
-"%DELPHI7ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI7ROOT%\lib" -E..\..\Files ISPPCC.dpr -DIS_ALLOWD7
+"%DELPHI7ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI7ROOT%\lib" -E..\..\Files -N..\..\lib\ISPP ISPPCC.dpr -DIS_ALLOWD7
 if errorlevel 1 goto failed
+echo.
 
 echo - ISPP.dpr
-"%DELPHI7ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI7ROOT%\lib" -E..\..\Files ISPP.dpr -DIS_ALLOWD7
+"%DELPHI7ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI7ROOT%\lib" -E..\..\Files -N..\..\lib\ISPP ISPP.dpr -DIS_ALLOWD7
 if errorlevel 1 goto failed
+echo.
 
 cd ..
 
 echo - Compil32.dpr
-"%DELPHI3ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI3ROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST Compil32.dpr
+"%DELPHI3ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI3ROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST Compil32.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - ISCC.dpr
-"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST ISCC.dpr
+"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST ISCC.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - ISCmplr.dpr
-"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST ISCmplr.dpr
+"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST ISCmplr.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - SetupLdr.dpr
-"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components" -E..\Files SetupLdr.dpr
+"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components" -E..\Files -N..\lib SetupLdr.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - Setup.dpr
-"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST Setup.dpr
+"%DELPHIROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHIROOT%\lib;..\Components;%ROPSPATH%" -E..\Files -N..\lib -DPS_MINIVCL;PS_NOWIDESTRING;PS_NOINT64;PS_NOGRAPHCONST Setup.dpr
 if errorlevel 1 goto failed
+echo.
 
 echo - Renaming files
 cd ..\Files


### PR DESCRIPTION
The compile scripts spread the generated *.dcu files all over the repository. This branch forces the compiler to create the files only in the /lib or /lib/ISPP directory. It also updates the D2009 dproj files to match the compile script's define and path settings.

All old *.dcu files should be deleted from the repository after this branch is merged so that the compiler won't use the outdated files.
