### PR TITLE
Call RmShutdown() with proper action flags

### DIFF
--- a/Projects/Install.pas
+++ b/Projects/Install.pas
@@ -2772,14 +2772,14 @@ var
 
     RmDoRestart := True;
 
-    Error := RmShutdown(RmSessionHandle, 0, nil);
+    Error := RmShutdown(RmSessionHandle, RmForceShutdown or RmShutdownOnlyRegistered, nil);
     while Error = ERROR_FAIL_SHUTDOWN do begin
       Log('Some applications could not be shut down.');
       if AbortRetryIgnoreMsgBox(SetupMessages[msgErrorCloseApplications],
          SetupMessages[msgEntryAbortRetryIgnore]) then
         Break;
       Log('Retrying to shut down applications using our files.');
-      Error := RmShutdown(RmSessionHandle, 0, nil);
+      Error := RmShutdown(RmSessionHandle, RmForceShutdown or RmShutdownOnlyRegistered, nil);
     end;
 
     { Close session on all errors except for ERROR_FAIL_SHUTDOWN, should still call RmRestart in that case. }


### PR DESCRIPTION
[1] states that the "lActionFlags" parameter has to be "One or more
RM_SHUTDOWN_TYPE options" that "can be combined by an OR operator". Thus,
passing 0 is invalid, valid options are combinations of "RmForceShutdown"
and "RmShutdownOnlyRegistered".

Only use "RmShutdownOnlyRegistered" here for now as there should be a
separate user confirmation to force the shutdown of applications that do
not support being restarted by calling RegisterApplicationRestart().

[1]
http://msdn.microsoft.com/en-us/library/windows/desktop/aa373667%28v=vs.85%29.aspx
