### PR TITLE
Fix ide hanging when file modified outside of it

### DIFF
--- a/Projects/CmnFunc.pas
+++ b/Projects/CmnFunc.pas
@@ -268,7 +268,8 @@ begin
   TriggerMessageBoxCallbackFunc(Flags, False);
   try
 {$IFDEF IS_D4}
-    Result := MessageBox(Application.MainFormHandle, Text, Caption, Flags);
+    { On Delphi 4+, simply call Application.MessageBox }
+    Result := Application.MessageBox(Text, Caption, Flags);
 {$ELSE}
     { Use custom implementation on Delphi 2 and 3. The Flags parameter is
       incorrectly declared as a Word on Delphi 2's Application.MessageBox, and

--- a/Projects/CmnFunc.pas
+++ b/Projects/CmnFunc.pas
@@ -250,7 +250,7 @@ begin
 
   { If the application window isn't currently visible, show the message box
     with no owner window so it'll get a taskbar button } 
-  if (GetWindowLong(Application.Handle, GWL_STYLE) and WS_VISIBLE = 0) or
+  if IsIconic(Application.Handle) or (GetWindowLong(Application.Handle, GWL_STYLE) and WS_VISIBLE = 0) or
      (GetWindowLong(Application.Handle, GWL_EXSTYLE) and WS_EX_TOOLWINDOW <> 0) then begin
     ActiveWindow := GetActiveWindow;
     WindowList := DisableTaskWindows(0);

--- a/Projects/CmnFunc.pas
+++ b/Projects/CmnFunc.pas
@@ -268,8 +268,7 @@ begin
   TriggerMessageBoxCallbackFunc(Flags, False);
   try
 {$IFDEF IS_D4}
-    { On Delphi 4+, simply call Application.MessageBox }
-    Result := Application.MessageBox(Text, Caption, Flags);
+    Result := MessageBox(Application.MainFormHandle, Text, Caption, Flags);
 {$ELSE}
     { Use custom implementation on Delphi 2 and 3. The Flags parameter is
       incorrectly declared as a Word on Delphi 2's Application.MessageBox, and


### PR DESCRIPTION
This PR fixes issue #112 

I could almost-reliably reproduce the issue at hand.

The problem would be that the message box is created as a modal window, then the main form is restored thus causing it (the message box) to stay behind the main form and causing it to freeze or simply not respond.

If you would drag away the form to reveal the message box then answer it the application starts responding normally.

This PR fixes this anomaly.