### PR TITLE
updated TBitmapImage with support of GDI compatible 32-bit RGBA bitmaps

### DIFF
--- a/Components/ScintStylerInnoSetup.pas
+++ b/Components/ScintStylerInnoSetup.pas
@@ -130,6 +130,7 @@ type
     ssBackColor2,
     ssBackColorDirection,
     ssBackSolid,
+    ssBitmapAlphaFormat,
     ssChangesAssociations,
     ssChangesEnvironment,
     ssCloseApplications,

--- a/Projects/Compile.pas
+++ b/Projects/Compile.pas
@@ -89,6 +89,7 @@ type
     ssBackColor2,
     ssBackColorDirection,
     ssBackSolid,
+    ssBitmapAlphaFormat,
     ssChangesAssociations,
     ssChangesEnvironment,
     ssCloseApplications,
@@ -3684,6 +3685,16 @@ begin
     ssBackSolid: begin
         BackSolid := StrToBool(Value);
       end;
+    ssBitmapAlphaFormat: begin
+        if CompareText(Value, 'none') = 0 then
+          SetupHeader.BitmapAlphaFormat := afIgnored
+        else if CompareText(Value, 'defined') = 0 then
+          SetupHeader.BitmapAlphaFormat := afDefined
+        else if CompareText(Value, 'premultiplied') = 0 then
+          SetupHeader.BitmapAlphaFormat := afPremultiplied
+        else
+          Invalid;
+    end;
     ssChangesAssociations: begin
         SetSetupHeaderOption(shChangesAssociations);
       end;
@@ -8309,6 +8320,7 @@ begin
     SetupHeader.DefaultUserInfoOrg := '{sysuserinfoorg}';
     SetupHeader.BackColor := clBlue;
     SetupHeader.BackColor2 := clBlack;
+    SetupHeader.BitmapAlphaFormat := afIgnored;
     SetupHeader.DisableDirPage := dpAuto;
     SetupHeader.DisableProgramGroupPage := dpAuto;
     SetupHeader.CreateUninstallRegKey := 'yes';

--- a/Projects/Main.pas
+++ b/Projects/Main.pas
@@ -250,7 +250,7 @@ uses
   Compress, CompressZlib, bzlib, LZMADecomp, ArcFour, SetupEnt, SelLangForm,
   Wizard, DebugClient, VerInfo, Extract, FileClass, Logging, MD5, SHA1,
   {$IFNDEF Delphi3orHigher} OLE2, {$ELSE} ActiveX, {$ENDIF}
-  SimpleExpression, Helper, SpawnClient, SpawnServer, LibFusion;
+  SimpleExpression, Helper, SpawnClient, SpawnServer, LibFusion, BitmapImage;
 
 {$R *.DFM}
 
@@ -2557,7 +2557,8 @@ var
     try
       ReadFileIntoStream(MemStream, R);
       MemStream.Seek(0, soFromBeginning);
-      WizardImage := TBitmap.Create;
+      WizardImage := TAlphaBitmap.Create;
+      TAlphaBitmap(WizardImage).AlphaFormat := TAlphaFormat(SetupHeader.BitmapAlphaFormat);
       WizardImage.LoadFromStream(MemStream);
     finally
       MemStream.Free;

--- a/Projects/Struct.pas
+++ b/Projects/Struct.pas
@@ -100,6 +100,7 @@ type
       NumRunEntries, NumUninstallRunEntries: Integer;
     MinVersion, OnlyBelowVersion: TSetupVersionData;
     BackColor, BackColor2, WizardImageBackColor: Longint;
+    BitmapAlphaFormat: (afIgnored, afDefined, afPremultiplied); // Same as Graphics.TAlphaFormat
     PasswordHash: TSHA1Digest;
     PasswordSalt: TSetupSalt;
     ExtraDiskSpaceRequired: Integer64;


### PR DESCRIPTION
There are few limitations: the BMP must be in GDI compatible 32-bit format with pre-multiplied alpha. Some installers that relied on `TBitmapImage` background color replacing feature may break if they used 32-bit RGBX format that is identical to RGBA format and thus will use new painting method (in this case the image may have different background or be rendered completely transparent - conversion to 24-bit will fix that, there is no reason to use less compact format anyway). RGBA images generated by some imaging software may not be supported (GIMP uses bitfields compression method that is not natively supported and does not pre-multiply alpha). Use of third-party software may be needed to generate properly formatted input (ie. Pixelformer).