### PR TITLE
Add NewLine preprocessor macro

### DIFF
--- a/Files/ISPPBuiltins.iss
+++ b/Files/ISPPBuiltins.iss
@@ -50,8 +50,13 @@
 //
 #ifndef __POPT_P__
 # define private CStrings
-# pragma parseroption -p+
+#else
+# pragma parseroption -p-
 #endif
+
+#define NewLine "\n"
+#pragma parseroption -p+
+
 //
 #pragma spansymbol "\"
 //


### PR DESCRIPTION
There seems to be no way to emit a new line in the default Pascal-style preprocessor string syntax.
https://stackoverflow.com/q/45999277/850848
This change adds NewLine macro that can be used for emit a new line, to avoid a need to switch to C-style strings just for this.