### PR TITLE
TWizardPage Surface properties are read-only

### DIFF
--- a/ISHelp/isxclasses.pas
+++ b/ISHelp/isxclasses.pas
@@ -627,9 +627,9 @@ TWizardPage = class(TComponent)
   property ID: Integer; read;
   property Caption: String; read write;
   property Description: String; read write;
-  property Surface: TNewNotebookPage; read write;
-  property SurfaceHeight: Integer; read write;
-  property SurfaceWidth: Integer; read write;
+  property Surface: TNewNotebookPage; read;
+  property SurfaceHeight: Integer; read;
+  property SurfaceWidth: Integer; read;
   property OnActivate: TWizardPageNotifyEvent; read write;
   property OnBackButtonClick: TWizardPageButtonEvent; read write;
   property OnCancelButtonClick: TWizardPageCancelEvent; read write;


### PR DESCRIPTION
From http://news.jrsoftware.org/news/innosetup.code/msg30651.html (not indexed yet, but I assume that will eventually be its URL).

Newsgroups: jrsoftware.innosetup.code
Subject: Confusing documentation for the TWizardPage class
Date: Mon, 16 Jul 2018 06:35:34 +0000 (UTC)

Suggested fix to help based on https://github.com/jrsoftware/issrc/blob/b09ec647bb2a09641265b1b2c0e9bb7715732782/Projects/Wizard.pas#L68-L70