### PR TITLE
Update README formatting, add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ stored in a compiled resource file.
 **Projects\Lzma2\Decoder\ISLzmaDec.obj**, **Projects\Lzma2\Decoder\ISLzma2Dec.obj** -
 See [Projects\Lzma2\Decoder\compiling.txt].
 
-**ISHelp\ISHelpGen\ISHelpGen.exe** - See [ISHelp\ISHelpGen\compile.bat].
+**ISHelp\ISHelpGen\ISHelpGen.exe** - See [ISHelp\compile.bat].
 
 **Examples\MyProg.exe**, **Examples\MyProg-x64.exe** - Compiled by Visual Studio
 2005 from the [Examples\MyProg] directory.
@@ -231,4 +231,4 @@ Inno Setup-specific editing guidelines for the help files
 [Examples\MyProg]: <Examples/MyProg>
 [Projects\LzmaDecode\compiling.txt]: <Projects/LzmaDecode/compiling.txt>
 [Projects\Lzma2\Decoder\compiling.txt]: <Projects/Lzma2/Decoder/compiling.txt>
-[ISHelp\ISHelpGen\compile.bat]: <ISHelp/ISHelpGen/compile.bat>
+[ISHelp\compile.bat]: <ISHelp/compile.bat>

--- a/README.md
+++ b/README.md
@@ -7,80 +7,85 @@ For conditions of distribution and use, see LICENSE.TXT.
 
 Source code README
 
-1. Getting Started
-------------------
+Getting Started
+---------------
 
-- Obtaining sources
+1. **Obtain sources**
 
-  First you need to download the sources from Github. From the command line do:
+    First you need to download the sources from Github. From the command line do:
 
-  ```
-  > git clone https://github.com/jrsoftware/issrc.git is
-  > cd is
-  > git submodule init
-  > git submodule update
-  ```
+    ```
+    > git clone https://github.com/jrsoftware/issrc.git is
+    > cd is
+    > git submodule init
+    > git submodule update
+    ```
 
-  If you don't have the Git client (`git`), get it from:
+    If you don't have the Git client (`git`), get it from:
 
-  http://git-scm.com/
+    http://git-scm.com/
 
-  To update your sources from the command line do:
-  ```
-  > git pull
-  > git submodule update
-  ```
+    To update your sources from the command line do:
+    ```
+    > git pull
+    > git submodule update
+    ```
 
-  To be able to contribute to Inno Setup, clone your own fork instead of
-  cloning the main Inno Setup repository, commit your work on topic branches
-  and make pull requests. See [CONTRIBUTING.md](CONTRIBUTING.md).
+    To be able to contribute to Inno Setup, clone your own fork instead of
+    cloning the main Inno Setup repository, commit your work on topic branches
+    and make pull requests. See [CONTRIBUTING.md].
 
-- Install Embarcadero Delphi
 
-  We compile all of Inno Setup's projects under Delphi 10.2 Tokyo Release 2.
+2. **Install Embarcadero Delphi**
+
+   We compile all of Inno Setup's projects under Delphi 10.2 Tokyo Release 2.
+
+   If you do not have access to this version of Delphi, you should be
+   able to compile the projects on later versions, however complete
+   compatibility is NOT guaranteed. We try to make Inno Setup compilable on
+   the later versions when possible, but do not have the resources to test
+   every change on every Delphi version.
   
-  If you do not have access to this version of Delphi, you should be
-  able to compile the projects on later versions, however complete
-  compatibility is NOT guaranteed. We try to make Inno Setup compilable on
-  the later versions when possible, but do not have the resources to test
-  every change on every Delphi version.
-  
-  There's a free version of Delphi available called the Community Edition.
-  See https://www.embarcadero.com/products/delphi/starter/free-download
+   There's a free version of Delphi available called the Community Edition.
+   See https://www.embarcadero.com/products/delphi/starter/free-download
 
-- Install Microsoft MSXML
 
-  Install Microsoft MSXML 4.0 SP2 if you haven't already done so.
-  See http://www.microsoft.com/en-us/download/details.aspx?id=19662
+3. **Install Microsoft MSXML**
 
-  If you are not sure whether you have MSXML 4.0 SP2 already, check for a
-  file named msxml4.dll in your Windows System directory with a version number
-  of 4.20.9818.0 (or later).
+   Install Microsoft MSXML 4.0 SP2 if you haven't already done so.
+   See http://www.microsoft.com/en-us/download/details.aspx?id=19662
 
-  Note: Microsoft MSXML is only needed to be able to compile the help files.
+   If you are not sure whether you have MSXML 4.0 SP2 already, check for a
+   file named msxml4.dll in your Windows System directory with a version number
+   of 4.20.9818.0 (or later).
 
-- Install Microsoft HTML Help Workshop
+   Note: Microsoft MSXML is only needed to be able to compile the help files.
 
-  Install Microsoft HTML Help Workshop if you haven't already done so.
-  See http://www.microsoft.com/en-us/download/details.aspx?id=21138
 
-  Note: Microsoft HTML Help Workshop is only needed to be able to compile the
-  help files.
+4. **Install Microsoft HTML Help Workshop**
 
-- Building
+   Install Microsoft HTML Help Workshop if you haven't already done so.
+   See http://www.microsoft.com/en-us/download/details.aspx?id=21138
 
-  To build all files run **build.bat** and follow the instructions.
+   Note: Microsoft HTML Help Workshop is only needed to be able to compile the
+   help files.
 
-  To just compile Inno Setup run **compile.bat** and follow the instructions.
 
-  To just compile the Inno Setup help file and its web version run
-  **ISHelp\compile.bat** and follow the instructions.
+5. **Build Inno Setup**
 
-  To just compile the Inno Setup Preprocessor help file and its web version run
-  **Projects\Ispp\Help\compile.bat** and follow the instructions.
+   To build all files run **build.bat** and follow the instructions.
 
-2. Component Installation
--------------------------
+   To just compile Inno Setup run **compile.bat** and follow the instructions.
+
+   To just compile the Inno Setup help file and its web version run
+   **ISHelp\compile.bat** and follow the instructions.
+
+   To just compile the Inno Setup Preprocessor help file and its web version run
+   **Projects\Ispp\Help\compile.bat** and follow the instructions.
+
+
+Component Installation
+----------------------
 
 If you intend to view or modify the Setup project's forms, you must install
 the following component units, which can be found in the Components
@@ -106,8 +111,9 @@ If you only want to edit code, then you may skip installation of the
 components, and choose "Cancel" if the Delphi IDE tells you a class can't
 be found.
 
-3. Overview
------------
+
+Overview
+--------
 
 Inno Setup consists of seven projects:
 
@@ -145,17 +151,18 @@ How do the projects link together?
   particular unit.
 
 - The ISPP help file uses various copies of other Inno Setup files. To synch
-  these run synch-isfiles.bat.
+  these run **synch-isfiles.bat**.
 
-4. Source code tips
--------------------
+
+Source code tips
+----------------
 
 - If you modify the Setup or SetupLdr projects and want to be able to compile
   your installations with the new code, you'll need to copy the new EXE
   file(s) to the Setup Compiler directory under the extension .E32.
 
-- When debugging the Setup project you should set UseSetupLdr=no and
-  OutputBaseFilename=setup in your script, and copy the resulting setup-*.bin
+- When debugging the Setup project you should set ``UseSetupLdr=no`` and
+  ``OutputBaseFilename=setup`` in your script, and copy the resulting setup-*.bin
   files to the source code directory. This way you can simulate an actual
   installation while running under the Delphi debugger.
 
@@ -171,8 +178,9 @@ How do the projects link together?
 - For compiler debugging purposes define ``STATICCOMPILER`` in CompForm.pas
   and ``STATICPREPROC`` in Compile.pas.
 
-5. Precompiled executables and libraries
-----------------------------------------
+
+Precompiled executables and libraries
+-------------------------------------
 
 The source code contains several precompiled executables and libraries:
 
@@ -183,7 +191,7 @@ from the bzlib directory in the Iscompress repository.
 from the zlib-dll directory in the Iscompress repository.
 
 **Files\islzma.dll**, **Files\islzma32.exe**, **Files\islzma64.exe** - Compiled
-by Visual Studio 2005 from the Projects\Lzma2\Encoder directory.
+by Visual Studio 2005 from the [Projects\Lzma2\Encoder] directory.
 
 **Files\isscint.dll** - Compiled by Visual Studio 2005 from Scintilla 2.22 source
 code with scintilla-2.22-patch.txt applied.
@@ -193,25 +201,34 @@ NT 4.0 stored in a compiled resource file. Note: this file is normally not
 actually used by Setup.
 
 **Projects\Helper\x64\Release\Helper.exe**, **Projects\HelperEXEs.res** -
-Compiled by Visual Studio 2005 from the Projects\Helper directory and then
+Compiled by Visual Studio 2005 from the [Projects\Helper] directory and then
 stored in a compiled resource file.
 
-**Projects\LzmaDecode\LzmaDecodeInno.obj** - See Projects\LzmaDecode\compiling.txt.
+**Projects\LzmaDecode\LzmaDecodeInno.obj** - See [Projects\LzmaDecode\compiling.txt].
 
 **Projects\Lzma2\Decoder\ISLzmaDec.obj**, **Projects\Lzma2\Decoder\ISLzma2Dec.obj** -
-See Projects\Lzma2\Decoder\compiling.txt.
+See [Projects\Lzma2\Decoder\compiling.txt].
 
-**ISHelp\ISHelpGen\ISHelpGen.exe** - See ISHelp\ISHelpGen\compile.bat
+**ISHelp\ISHelpGen\ISHelpGen.exe** - See [ISHelp\ISHelpGen\compile.bat].
 
 **Examples\MyProg.exe**, **Examples\MyProg-x64.exe** - Compiled by Visual Studio
-2005 from the Examples\MyProg directory.
+2005 from the [Examples\MyProg] directory.
 
 **Examples\MyProg-ARM64.exe** - Compiled by Visual Studio 2017 from the
-Examples\MyProg directory.
+[Examples\MyProg] directory.
 
-6. Inno Setup-specific editing guidelines for the help files
-------------------------------------------------------------
+Inno Setup-specific editing guidelines for the help files
+---------------------------------------------------------
 
 - When mentioning something the user would type in a script, e.g. "MinVersion",
   surround it by `<tt></tt>` so that it's displayed in the Courier New font. This is
   a convention used throughout the help file. Example: `<tt>MinVersion</tt>`
+
+<!-- Link references -->
+[CONTRIBUTING.md]: <CONTRIBUTING.md>
+[Projects\Lzma2\Encoder]: <Projects/Lzma2/Encoder>
+[Projects\Helper]: <Projects/Helper>
+[Examples\MyProg]: <Examples/MyProg>
+[Projects\LzmaDecode\compiling.txt]: <Projects/LzmaDecode/compiling.txt>
+[Projects\Lzma2\Decoder\compiling.txt]: <Projects/Lzma2/Decoder/compiling.txt>
+[ISHelp\ISHelpGen\compile.bat]: <ISHelp/ISHelpGen/compile.bat>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ be found.
 Overview
 --------
 
-Inno Setup consists of seven projects:
+Inno Setup consists of six projects:
 
 **Compil32** - This is the GUI front-end for the compiler. Compil32 does not
 do the actual compilation itself; it relegates it to ISCmplr.dll. If the


### PR DESCRIPTION
The README wasn't formatting as intended on GitHub, because the numbers in the section titles prevented them from being interpreted as [setext headings](https://github.github.com/gfm/#setext-headings) despite the underlining.

While it would've been possible to retain the numbering by reformatting, e.g.:

```markdown
1 - Getting Started
---------------------
```

I chose to eliminate the numbers, and instead convert the steps of the _first_ section into an ordered list. (Having both the sections and the steps numbered proved to be too busy and confusing.) That section's list item contents were also shifted right one extra space, to account for the insertion of list numbering.

I also added reference links to many of the internal directory and file paths mentioned. For maximum plain-text readability, I used short reference links, and collected the expanded links at the very bottom of the file after an HTML comment. So for example:

```markdown
**Files\islzma.dll**, **Files\islzma32.exe**, **Files\islzma64.exe** - Compiled
by Visual Studio 2005 from the [Projects\Lzma2\Encoder] directory.

<!-- At the end of the file, the link is defined... -->
[Projects\Lzma2\Encoder]: <Projects/Lzma2/Encoder>
```

There's also some other misc cleanup, like correcting the number of projects in the source tree, using a consistent mood (imperative, rather than indicative) for all of the steps in "Getting Started", and adding markup in a couple of places.