### PR TITLE
An incomplete sketch of a version class.

### DIFF
--- a/Projects/ScriptClasses_C.pas
+++ b/Projects/ScriptClasses_C.pas
@@ -25,6 +25,25 @@ uses
   uPSC_std, uPSC_classes, uPSC_graphics, uPSC_controls, uPSC_stdctrls,
   uPSC_forms, uPSC_extctrls, uPSC_comobj;
 
+procedure RegisterVersion_C(Cl: TPSPascalCompiler);
+begin
+  with Cl.AddClassN(Cl.FindClass('TObject'), 'TVersion') do
+  begin
+    RegisterProperty('Major', 'Word', iptrw);
+    RegisterProperty('Minor', 'Word', iptrw);
+    RegisterProperty('Revision', 'Word', iptrw);
+    RegisterProperty('Build', 'Word', iptrw);
+    RegisterProperty('MS', 'Cardinal', iptrw);
+    RegisterProperty('LS', 'Cardinal', iptrw);
+    RegisterProperty('Value', 'Int64', iptrw);
+    RegisterMethod('constructor Create(Major, Minor, Revision, Build: Word);');
+    RegisterMethod('constructor CreateFromNumbers(MS, LS: Cardinal);');
+    RegisterMethod('constructor CreateFromValue(Value: Int64);');
+    RegisterMethod('function ToStr(): String;');
+    RegisterMethod('function Compare(Other: TVersion): Integer;');
+  end;
+end;
+
 procedure RegisterWinControl_C(Cl: TPSPascalCompiler);
 begin
   SIRegisterTWinControl(Cl);
@@ -621,6 +640,7 @@ begin
   { ComObj }
   SIRegister_ComObj(Cl);
 
+  RegisterVersion_C(Cl);
   RegisterNewStaticText_C(Cl);
   RegisterNewCheckListBox_C(Cl);
   RegisterNewProgressBar_C(Cl);

--- a/Projects/ScriptClasses_R.pas
+++ b/Projects/ScriptClasses_R.pas
@@ -27,11 +27,60 @@ uses
   uPSR_stdctrls, uPSR_extctrls, uPSR_comobj, {$IFNDEF UNICODE} uPSUtils, {$ENDIF}
   NewStaticText, NewCheckListBox, NewProgressBar, RichEditViewer,
   ExtCtrls, UIStateForm, SetupForm, Main, Wizard, SetupTypes, PasswordEdit,
-  FolderTreeView, BitmapImage, NewNotebook, ScriptDlg, BidiCtrls,
+  FolderTreeView, BitmapImage, NewNotebook, ScriptDlg, BidiCtrls, VerInfo,
   UninstProgressForm;
 
 type
   TWinControlAccess = class(TWinControl);
+  TVersionObj = class
+    Version: TVersion;
+    constructor Create(Major, Minor, Revision, Build: Word);
+    constructor CreateFromNumbers(MS, LS: Cardinal);
+    constructor CreateFromValue(Value: Int64);
+    function ToStr(): String;
+    function Compare(Other: TVersionObj): Integer;
+  end;
+
+constructor TVersionObj.Create(Major: Word; Minor: Word; Revision: Word; Build: Word);
+begin Version.Major := Major; Version.Minor := Minor; Version.Revision := Revision; Version.Build := Build; end;
+constructor TVersionObj.CreateFromNumbers(MS: Cardinal; LS: Cardinal);
+begin Version.MS := MS; Version.LS := LS; end;
+constructor TVersionObj.CreateFromValue(Value: Int64); begin Version.Value := Value; end;
+function TVersionObj.ToStr(): String; begin Result := Version.ToStr(); end;
+function TVersionObj.Compare(Other: TVersionObj): Integer; begin Result := Version.Compare(Other.Version); end;
+procedure TVersionMajor_R(Self: TVersionObj; var T: Word); begin T := Self.Version.Major; end;
+procedure TVersionMajor_W(Self: TVersionObj; const T: Word); begin Self.Version.Major := T; end;
+procedure TVersionMinor_R(Self: TVersionObj; var T: Word); begin T := Self.Version.Minor; end;
+procedure TVersionMinor_W(Self: TVersionObj; const T: Word); begin Self.Version.Minor := T; end;
+procedure TVersionRevision_R(Self: TVersionObj; var T: Word); begin T := Self.Version.Revision; end;
+procedure TVersionRevision_W(Self: TVersionObj; const T: Word); begin Self.Version.Revision := T; end;
+procedure TVersionBuild_R(Self: TVersionObj; var T: Word); begin T := Self.Version.Build; end;
+procedure TVersionBuild_W(Self: TVersionObj; const T: Word); begin Self.Version.Build := T; end;
+procedure TVersionMS_R(Self: TVersionObj; var T: Cardinal); begin T := Self.Version.MS; end;
+procedure TVersionMS_W(Self: TVersionObj; const T: Cardinal); begin Self.Version.MS := T; end;
+procedure TVersionLS_R(Self: TVersionObj; var T: Cardinal); begin T := Self.Version.LS; end;
+procedure TVersionLS_W(Self: TVersionObj; const T: Cardinal); begin Self.Version.LS := T; end;
+procedure TVersionValue_R(Self: TVersionObj; var T: Int64); begin T := Self.Version.Value; end;
+procedure TVersionValue_W(Self: TVersionObj; const T: Int64); begin Self.Version.Value := T; end;
+
+procedure RegisterVersion_R(Cl: TPSRuntimeClassImporter);
+begin
+  with Cl.Add2(TVersionObj, 'TVersion') do
+  begin
+    RegisterPropertyHelper(@TVersionMajor_R, @TVersionMajor_W, 'Major');
+    RegisterPropertyHelper(@TVersionMinor_R, @TVersionMinor_W, 'Minor');
+    RegisterPropertyHelper(@TVersionRevision_R, @TVersionRevision_W, 'Revision');
+    RegisterPropertyHelper(@TVersionBuild_R, @TVersionBuild_W, 'Build');
+    RegisterPropertyHelper(@TVersionMS_R, @TVersionMS_W, 'MS');
+    RegisterPropertyHelper(@TVersionLS_R, @TVersionLS_W, 'LS');
+    RegisterPropertyHelper(@TVersionValue_R, @TVersionValue_W, 'Value');
+    RegisterConstructor(@TVersionObj.Create, 'Create');
+    RegisterConstructor(@TVersionObj.CreateFromNumbers, 'CreateFromNumbers');
+    RegisterConstructor(@TVersionObj.CreateFromValue, 'CreateFromValue');
+    RegisterMethod(@TVersionObj.ToStr, 'ToStr');
+    RegisterMethod(@TVersionObj.Compare, 'Compare');
+  end;
+end;
 
 procedure TWinControlParentBackground_R(Self: TWinControl; var T: Boolean); begin {$IFDEF IS_D7} T := TWinControlAccess(Self).ParentBackground {$ELSE} T := False {$ENDIF}; end;
 procedure TWinControlParentBackground_W(Self: TWinControl; const T: Boolean); begin {$IFDEF IS_D7} TWinControlAccess(Self).ParentBackground := T; {$ENDIF} end;
@@ -387,6 +436,7 @@ begin
     { ComObj }
     RIRegister_ComObj(ScriptInterpreter);
 
+    RegisterVersion_R(Cl);
     RegisterNewStaticText_R(Cl);
     RegisterNewCheckListBox_R(Cl);
     RegisterNewProgressBar_R(Cl);

--- a/Projects/Verinfo.pas
+++ b/Projects/Verinfo.pas
@@ -23,6 +23,17 @@ type
     MS, LS: LongWord;
   end;
 
+  {This makes some layout assumptions, but it's similar to LARGE_INTEGER}
+  TVersion = record
+    constructor Create(Version: TFileVersionNumbers);
+    function Compare(const Other: TVersion): Integer;
+    function ToStr(): String;
+  case Integer of
+    0: (Value: Int64);
+    1: (LS, MS: LongWord);
+    2: (Build, Revision, Minor, Major: Word);
+  end;
+
 function GetVersionInfo(const Filename: String;
   var VersionInfo: TVSFixedFileInfo): Boolean;
 function GetVersionNumbers(const Filename: String;
@@ -32,6 +43,24 @@ implementation
 
 uses
   CmnFunc2, FileClass;
+
+constructor TVersion.Create(Version: TFileVersionNumbers);
+begin
+  MS := Version.MS;
+  LS := Version.LS;
+end;
+
+function TVersion.Compare(const Other: TVersion): Integer;
+begin
+  if Value < Other.Value then Result := -1
+  else if Value > Other.Value then Result := 1
+  else Result := 0;
+end;
+
+function TVersion.ToStr(): String;
+begin
+  Result := Format('%u.%u.%u.%u', [Major, Minor, Revision, Build]);
+end;
 
 function GetVXDVersionInfo(const Filename: String;
   var VersionInfo: TVSFixedFileInfo): Boolean;


### PR DESCRIPTION
This is an alternate-timeline version of #337, which might be irrelevant now that you've merged that, but I thought I'd share it anyway.

It's incomplete (lacking docs), but it does work.

I'm not entirely happy with it since it requires an explicit heap `Create` in the Inno script (which then also means a `Free` that everyone will forget to write).

But on the plus side, it does allow a bit more natural syntax:

```
  Version := TVersion.Create(1, 2, 3, 4); // or CreateFromNumbers(MyAppMS, MyAppLS)
  // can now access Version.Value, or Version.MS/LS, or Version.Major/Minor/Revision/Build
  // or use Version.ToStr() or Version.Compare(AnotherVersion)
  // assigning to any of the properties updates the other properties as well,
  // so conversions Just Work™
  Version.Free;  // but everyone will forget to do this
```

Unfortunately I didn't see any obvious way to make ROPS accept a non-class with properties.  (But it is a non-class in the native Inno side such that theoretically the installer itself could make use of it anywhere else it wants to deal with version numbers, and get the more efficient version.)

(An overloaded `Create` would also have been nicer; I didn't actually test that but I assume it's not supported.)