### PR TITLE
Automatically open #include files

### DIFF
--- a/Components/NewTabSet.pas
+++ b/Components/NewTabSet.pas
@@ -328,6 +328,8 @@ end;
 procedure TNewTabSet.SetTabs(Value: TStrings);
 begin
   FTabs.Assign(Value);
+  if FTabIndex >= FTabs.Count then
+    SetTabIndex(FTabs.Count-1);
 end;
 
 procedure TNewTabSet.SetTheme(Value: TTheme);

--- a/Components/ScintEdit.pas
+++ b/Components/ScintEdit.pas
@@ -260,6 +260,7 @@ type
     property AutoCompleteFontSize: Integer read FAutoCompleteFontSize
       write SetAutoCompleteFontSize default 0;
     property CodePage: Integer read FCodePage write SetCodePage default 0;
+    property Color;
     property FillSelectionToEdge: Boolean read FFillSelectionToEdge write SetFillSelectionToEdge
       default False;
     property Font;

--- a/Files/ISPPBuiltins.iss
+++ b/Files/ISPPBuiltins.iss
@@ -14,32 +14,37 @@
 //
 #define _BUILTINS_ISS_
 //
+#ifdef __OPT_E__
+# define private EnableOptE
+# pragma option -e-
+#endif
+
 #ifndef __POPT_P__
-# define private CStrings
+# define private DisablePOptP
 #else
 # pragma parseroption -p-
 #endif
-//
+
 #define NewLine            "\n"
 #define Tab                "\t"
-//
+
 #pragma parseroption -p+
-//
+
 #pragma spansymbol "\"
-//
+
 #define True               1
 #define False              0
 #define Yes                True
 #define No								 False
-//
+
 #define MaxInt             0x7FFFFFFFFFFFFFFFL
 #define MinInt             0x8000000000000000L
-//
+
 #define NULL
 #define void
-//
+
 // TypeOf constants
-//
+
 #define TYPE_ERROR         0
 #define TYPE_NULL          1
 #define TYPE_INTEGER       2
@@ -47,15 +52,15 @@
 #define TYPE_MACRO         4
 #define TYPE_FUNC          5
 #define TYPE_ARRAY         6
-//
+
 // Helper macro to find out the type of an array element or expression. TypeOf
 // standard function only allows identifier as its parameter. Use this macro
 // to convert an expression to identifier.
-//
+
 #define TypeOf2(any Expr) TypeOf(Expr)
-//
+
 // ReadReg constants
-//
+
 #define HKEY_CLASSES_ROOT  0x80000000UL
 #define HKEY_CURRENT_USER  0x80000001UL
 #define HKEY_LOCAL_MACHINE 0x80000002UL
@@ -66,7 +71,7 @@
 #define HKEY_LOCAL_MACHINE_64   0x82000002UL
 #define HKEY_USERS_64           0x82000003UL
 #define HKEY_CURRENT_CONFIG_64  0x82000005UL
-//
+
 #define HKCR               HKEY_CLASSES_ROOT
 #define HKCU               HKEY_CURRENT_USER
 #define HKLM               HKEY_LOCAL_MACHINE
@@ -77,9 +82,9 @@
 #define HKLM64             HKEY_LOCAL_MACHINE_64
 #define HKU64              HKEY_USERS_64
 #define HKCC64             HKEY_CURRENT_CONFIG_64
-//
+
 // Exec constants
-//
+
 #define SW_HIDE            0
 #define SW_SHOWNORMAL      1
 #define SW_NORMAL          1
@@ -94,9 +99,9 @@
 #define SW_RESTORE         9
 #define SW_SHOWDEFAULT     10
 #define SW_MAX             10
-//
+
 // Find constants
-//
+
 #define FIND_MATCH         0x00
 #define FIND_BEGINS        0x01
 #define FIND_ENDS          0x02
@@ -107,9 +112,9 @@
 #define FIND_OR            0x08
 #define FIND_NOT           0x10
 #define FIND_TRIM          0x20
-//
+
 // FindFirst constants
-//
+
 #define faReadOnly         0x00000001
 #define faHidden           0x00000002
 #define faSysFile          0x00000004
@@ -118,9 +123,9 @@
 #define faArchive          0x00000020
 #define faSymLink          0x00000040
 #define faAnyFile          0x0000003F
-//
+
 // GetStringFileInfo standard names
-//
+
 #define COMPANY_NAME       "CompanyName"
 #define FILE_DESCRIPTION   "FileDescription"
 #define FILE_VERSION       "FileVersion"
@@ -129,21 +134,21 @@
 #define ORIGINAL_FILENAME  "OriginalFilename"
 #define PRODUCT_NAME       "ProductName"
 #define PRODUCT_VERSION    "ProductVersion"
-//
+
 // GetStringFileInfo helpers
-//
+
 #define GetFileCompany(str FileName) GetStringFileInfo(FileName, COMPANY_NAME)
 #define GetFileDescription(str FileName) GetStringFileInfo(FileName, FILE_DESCRIPTION)
 #define GetFileVersionString(str FileName) GetStringFileInfo(FileName, FILE_VERSION)
 #define GetFileCopyright(str FileName) GetStringFileInfo(FileName, LEGAL_COPYRIGHT)
 #define GetFileOriginalFilename(str FileName) GetStringFileInfo(FileName, ORIGINAL_FILENAME)
 #define GetFileProductVersion(str FileName) GetStringFileInfo(FileName, PRODUCT_VERSION)
-//
+
 #define DeleteToFirstPeriod(str *S) \
   Local[1] = Copy(S, 1, (Local[0] = Pos(".", S)) - 1), \
   S = Copy(S, Local[0] + 1), \
   Local[1]
-//
+
 #define GetVersionComponents(str FileName, *Major, *Minor, *Rev, *Build) \
   Local[1]  = Local[0] = GetVersionNumbersString(FileName), \
   Local[1] == "" ? "" : ( \
@@ -152,42 +157,42 @@
     Rev     = Int(DeleteToFirstPeriod(Local[1])), \
     Build   = Int(Local[1]), \
   Local[0])
-//
+
 #define GetPackedVersion(str FileName, *Version) \
   Local[0] = GetVersionComponents(FileName, Local[1], Local[2], Local[3], Local[4]), \
   Version = PackVersionComponents(Local[1], Local[2], Local[3], Local[4]), \
   Local[0]
-//
+
 #define GetVersionNumbers(str FileName, *MS, *LS) \
   Local[0] = GetPackedVersion(FileName, Local[1]), \
   UnpackVersionNumbers(Local[1], MS, LS), \
   Local[0]
-//
+
 #define PackVersionNumbers(int VersionMS, int VersionLS) \
   VersionMS << 32 | (VersionLS & 0xFFFFFFFF)
-//
+
 #define PackVersionComponents(int Major, int Minor, int Rev, int Build) \
   Major << 48 | (Minor & 0xFFFF) << 32 | (Rev & 0xFFFF) << 16 | (Build & 0xFFFF)
-//
+
 #define UnpackVersionNumbers(int Version, *VersionMS, *VersionLS) \
   VersionMS = Version >> 32, \
   VersionLS = Version & 0xFFFFFFFF, \
   void
-//
+
 #define UnpackVersionComponents(int Version, *Major, *Minor, *Rev, *Build) \
   Major = Version >> 48, \
   Minor = (Version >> 32) & 0xFFFF, \
   Rev   = (Version >> 16) & 0xFFFF, \
   Build = Version & 0xFFFF, \
   void
-//
+
 #define VersionToStr(int Version) \
   Str(Version >> 48 & 0xFFFF) + "." + Str(Version >> 32 & 0xFFFF) + "." + \
   Str(Version >> 16 & 0xFFFF) + "." + Str(Version & 0xFFFF)
-//
+
 #define EncodeVer(int Major, int Minor, int Revision = 0, int Build = -1) \
   (Major & 0xFF) << 24 | (Minor & 0xFF) << 16 | (Revision & 0xFF) << 8 | (Build >= 0 ? Build & 0xFF : 0)
-//
+
 #define DecodeVer(int Version, int Digits = 3) \
   Str(Version >> 24 & 0xFF) + (Digits > 1 ? "." : "") + \
   (Digits > 1 ? \
@@ -196,10 +201,10 @@
     Str(Version >> 8 & 0xFF) + (Digits > 3 && (Local = Version & 0xFF) ? "." : "") : "") + \
   (Digits > 3 && Local ? \
     Str(Version & 0xFF) : "")
-//
+
 #define FindSection(str Section = "Files") \
   Find(0, "[" + Section + "]", FIND_MATCH | FIND_TRIM) + 1
-//
+
 #if VER >= 0x03000000
 # define FindNextSection(int Line) \
     Find(Line, "[", FIND_BEGINS | FIND_TRIM, "]", FIND_ENDS | FIND_AND)
@@ -209,12 +214,12 @@
 # define FindSectionEnd(str Section = "Files") \
     FindSection(Section) + EntryCount(Section)
 #endif
-//
+
 #define FindCode() \
     Local[1] = FindSection("Code"), \
     Local[0] = Find(Local[1] - 1, "program", FIND_BEGINS, ";", FIND_ENDS | FIND_AND), \
     (Local[0] < 0 ? Local[1] : Local[0] + 1)
-//
+
 #define ExtractFilePath(str PathName) \
   (Local[0] = \
     !(Local[1] = RPos("\", PathName)) ? \
@@ -224,32 +229,32 @@
     ((Local[2] = Len(Local[0])) == 2 && Copy(Local[0], Local[2]) == ":" ? \
       "\" : \
       "")
-//
+
 #define ExtractFileDir(str PathName) \
   RemoveBackslash(ExtractFilePath(PathName))
-//
+
 #define ExtractFileExt(str PathName) \
   Local[0] = RPos(".", PathName), \
   Copy(PathName, Local[0] + 1)
-//
+
 #define ExtractFileName(str PathName) \
   !(Local[0] = RPos("\", PathName)) ? \
     PathName : \
     Copy(PathName, Local[0] + 1)
-//
+
 #define ChangeFileExt(str FileName, str NewExt) \
   !(Local[0] = RPos(".", FileName)) ? \
     FileName + "." + NewExt : \
     Copy(FileName, 1, Local[0]) + NewExt
-//
+
 #define RemoveFileExt(str FileName) \
   !(Local[0] = RPos(".", FileName)) ? \
   FileName : \
   Copy(FileName, 1, Local[0] - 1)
-//
+
 #define AddBackslash(str S) \
   Copy(S, Len(S)) == "\" ? S : S + "\"
-//
+
 #define RemoveBackslash(str S) \
   Local[0] = Len(S), \
   Local[0] > 0 ? \
@@ -259,48 +264,52 @@
         Copy(S, 1, Local[0] - 1)) : \
       S : \
     ""
-//
+
 #define Delete(str *S, int Index, int Count = MaxInt) \
   S = Copy(S, 1, Index - 1) + Copy(S, Index + Count)
-//
+
 #define Insert(str *S, int Index, str Substr) \
   Index > Len(S) + 1 ? \
     S : \
     S = Copy(S, 1, Index - 1) + SubStr + Copy(S, Index)
-//
+
 #define YesNo(str S) \
   (S = LowerCase(S)) == "yes" || S == "true" || S == "1"
-//
+
 #define IsDirSet(str SetupDirective) \
   YesNo(SetupSetting(SetupDirective))
-//
+
 #define Power(int X, int P = 2) \
   !P ? 1 : X * Power(X, P - 1)
-//
+
 #define Min(int A, int B, int C = MaxInt)  \
   A < B ? A < C ? Int(A) : Int(C) : Int(B)
-//
+
 #define Max(int A, int B, int C = MinInt)  \
   A > B ? A > C ? Int(A) : Int(C) : Int(B)
-//
+
 #define SameText(str S1, str S2) \
   LowerCase(S1) == LowerCase(S2)
-//
+
 #define SameStr(str S1, str S2) \
   S1 == S2
-//
+
 #define WarnRenamedVersion(str OldName, str NewName) \
   Warning("Function """ + OldName + """ has been renamed. Use """ + NewName + "GetVersionComponents"" instead.")
-//
+
 #define ParseVersion(str FileName, *Major, *Minor, *Rev, *Build) \
   WarnRenamedVersion("ParseVersion", "GetVersionComponents"), \
   GetVersionComponents(FileName, Major, Minor, Rev, Build)
-//
+
 #define GetFileVersion(str FileName) \
   WarnRenamedVersion("GetFileVersion", "GetVersionNumbersString"), \
   GetVersionNumbersString(FileName)
-//
-#ifdef CStrings
+
+#ifdef DisablePOptP
 # pragma parseroption -p-
+#endif
+
+#ifdef EnableOptE
+# pragma option -e+
 #endif
 #endif

--- a/Projects/CompForm.dfm
+++ b/Projects/CompForm.dfm
@@ -348,6 +348,11 @@ object CompileForm: TCompileForm
           OnClick = FSaveEncodingItemClick
         end
       end
+      object FSaveAll: TMenuItem
+        Caption = 'Sa&ve All'
+        ShortCut = 24659
+        OnClick = FSaveAllClick
+      end
       object N1: TMenuItem
         Caption = '-'
       end

--- a/Projects/CompForm.dfm
+++ b/Projects/CompForm.dfm
@@ -181,19 +181,19 @@ object CompileForm: TCompileForm
       ShowHint = True
       TabOrder = 0
       Transparent = True
-      object NewButton: TToolButton
+      object NewMainFileButton: TToolButton
         Left = 0
         Top = 0
-        Hint = 'New (Ctrl+N)'
+        Hint = 'New Main Script (Ctrl+N)'
         ImageIndex = 0
-        OnClick = FNewClick
+        OnClick = FNewMainFileClick
       end
-      object OpenButton: TToolButton
+      object OpenMainFileButton: TToolButton
         Left = 23
         Top = 0
-        Hint = 'Open (Ctrl+O)'
+        Hint = 'Open Main Script (Ctrl+O)'
         ImageIndex = 1
-        OnClick = FOpenClick
+        OnClick = FOpenMainFileClick
       end
       object SaveButton: TToolButton
         Left = 46
@@ -313,15 +313,15 @@ object CompileForm: TCompileForm
     object FMenu: TMenuItem
       Caption = '&File'
       OnClick = FMenuClick
-      object FNew: TMenuItem
+      object FNewMainFile: TMenuItem
         Caption = '&New'
         ShortCut = 16462
-        OnClick = FNewClick
+        OnClick = FNewMainFileClick
       end
-      object FOpen: TMenuItem
+      object FOpenMainFile: TMenuItem
         Caption = '&Open...'
         ShortCut = 16463
-        OnClick = FOpenClick
+        OnClick = FOpenMainFileClick
       end
       object N19: TMenuItem
         Caption = '-'
@@ -351,7 +351,7 @@ object CompileForm: TCompileForm
       object N1: TMenuItem
         Caption = '-'
       end
-      object FMRUFilesSep: TMenuItem
+      object FMRUMainFilesSep: TMenuItem
         Caption = '-'
         Visible = False
       end

--- a/Projects/CompForm.dfm
+++ b/Projects/CompForm.dfm
@@ -331,9 +331,9 @@ object CompileForm: TCompileForm
         ShortCut = 16467
         OnClick = FSaveClick
       end
-      object FSaveAs: TMenuItem
+      object FSaveMainFileAs: TMenuItem
         Caption = 'Save &As...'
-        OnClick = FSaveAsClick
+        OnClick = FSaveClick
       end
       object FSaveEncoding: TMenuItem
         Caption = 'Save &Encoding'

--- a/Projects/CompForm.dfm
+++ b/Projects/CompForm.dfm
@@ -30,16 +30,16 @@ object CompileForm: TCompileForm
   end
   object BodyPanel: TPanel
     Left = 0
-    Top = 30
+    Top = 51
     Width = 361
-    Height = 215
+    Height = 194
     Align = alClient
     BevelOuter = bvNone
     FullRepaint = False
     TabOrder = 0
     object SplitPanel: TPanel
       Left = 0
-      Top = 107
+      Top = 86
       Width = 361
       Height = 4
       Cursor = crSizeNS
@@ -52,7 +52,7 @@ object CompileForm: TCompileForm
     end
     object StatusPanel: TPanel
       Left = 0
-      Top = 111
+      Top = 90
       Width = 361
       Height = 104
       Align = alBottom
@@ -294,6 +294,18 @@ object CompileForm: TCompileForm
         OnClick = HDocClick
       end
     end
+  end
+  object IncludedFilesTabSet: TNewTabSet
+    Left = 0
+    Top = 30
+    Width = 361
+    Height = 21
+    Align = alTop
+    TabIndex = 0
+    Tabs.Strings = (
+      'Main Script')
+    TabPosition = tpTop
+    OnClick = IncludedFilesTabSetClick
   end
   object MainMenu1: TMainMenu
     Left = 8

--- a/Projects/CompForm.dfm
+++ b/Projects/CompForm.dfm
@@ -295,7 +295,7 @@ object CompileForm: TCompileForm
       end
     end
   end
-  object IncludedFilesTabSet: TNewTabSet
+  object MemosTabSet: TNewTabSet
     Left = 0
     Top = 30
     Width = 361
@@ -305,7 +305,7 @@ object CompileForm: TCompileForm
     Tabs.Strings = (
       'Main Script')
     TabPosition = tpTop
-    OnClick = IncludedFilesTabSetClick
+    OnClick = MemosTabSetClick
   end
   object MainMenu1: TMainMenu
     Left = 8

--- a/Projects/CompForm.dfm
+++ b/Projects/CompForm.dfm
@@ -104,7 +104,7 @@ object CompileForm: TCompileForm
         TabOrder = 0
         OnDrawItem = CompilerOutputListDrawItem
       end
-      object TabSet: TNewTabSet
+      object OutputTabSet: TNewTabSet
         Left = 0
         Top = 83
         Width = 361
@@ -115,7 +115,7 @@ object CompileForm: TCompileForm
           'Compiler Output'
           'Debug Output'
           'Debug Call Stack')
-        OnClick = TabSetClick
+        OnClick = OutputTabSetClick
       end
     end
   end

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -507,7 +507,7 @@ type
     procedure Popup(X, Y: Integer); override;
   end;
 
-{ok}procedure TCompileFormMemoPopupMenu.Popup(X, Y: Integer);
+procedure TCompileFormMemoPopupMenu.Popup(X, Y: Integer);
 var
   Form: TCompileForm;
 begin
@@ -551,7 +551,7 @@ end;
 
 { TCompileForm }
 
-{ok}constructor TCompileForm.Create(AOwner: TComponent);
+constructor TCompileForm.Create(AOwner: TComponent);
 
   procedure ReadConfig;
   var
@@ -751,7 +751,7 @@ begin
   end;
 end;
 
-{ok}destructor TCompileForm.Destroy;
+destructor TCompileForm.Destroy;
 
   procedure SaveConfig;
   var
@@ -831,7 +831,7 @@ begin
     CanClose := False;
 end;
 
-{ok}procedure TCompileForm.FormKeyDown(Sender: TObject; var Key: Word;
+procedure TCompileForm.FormKeyDown(Sender: TObject; var Key: Word;
   Shift: TShiftState);
 begin
   if ShortCut(Key, Shift) = VK_ESCAPE then begin
@@ -919,7 +919,7 @@ begin
     Application.Title := NewCaption;
 end;
 
-{ok}procedure TCompileForm.UpdateNewMainFileButtons;
+procedure TCompileForm.UpdateNewMainFileButtons;
 begin
   if FOptions.UseWizard then begin
     FNewMainFile.Caption := '&New...';
@@ -932,7 +932,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.NewMainFile;
+procedure TCompileForm.NewMainFile;
 begin
   HideMainMemoError;
   FUninstExe := '';
@@ -953,7 +953,7 @@ begin
   FMainMemo.ClearUndo;
 end;
 
-{ok}procedure TCompileForm.NewMainFileUsingWizard;
+procedure TCompileForm.NewMainFileUsingWizard;
 var
   WizardForm: TWizardForm;
   SaveEnabled: Boolean;
@@ -992,7 +992,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.OpenFile(AMemo: TCompScintEdit; AFilename: String;
+procedure TCompileForm.OpenFile(AMemo: TCompScintEdit; AFilename: String;
   const MainMemoAddToRecentDocs: Boolean);
 
   function IsStreamUTF8Encoded(const Stream: TStream): Boolean;
@@ -1032,7 +1032,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.OpenMRUMainFile(const AFilename: String);
+procedure TCompileForm.OpenMRUMainFile(const AFilename: String);
 { Same as OpenFile, but offers to remove the file from the MRU list if it
   cannot be opened }
 begin
@@ -1046,7 +1046,7 @@ begin
   end;
 end;
 
-{ok}function TCompileForm.SaveFile(const AMemo: TCompScintEdit; const SaveAs: Boolean): Boolean;
+function TCompileForm.SaveFile(const AMemo: TCompScintEdit; const SaveAs: Boolean): Boolean;
 
   procedure SaveMemoTo(const FN: String);
   var
@@ -1112,7 +1112,7 @@ begin
     ModifyMRUMainFilesList(AMemo.Filename, True);
 end;
 
-{ok}function TCompileForm.ConfirmCloseFile(const PromptToSave: Boolean; const OnlyActiveMemo: Boolean): Boolean;
+function TCompileForm.ConfirmCloseFile(const PromptToSave: Boolean; const OnlyActiveMemo: Boolean): Boolean;
 
   function PromptToSaveMemo(const AMemo: TCompScintEdit): Boolean;
 var
@@ -1158,7 +1158,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.ReadMRUMainFilesList;
+procedure TCompileForm.ReadMRUMainFilesList;
 begin
   try
     ReadMRUList(FMRUMainFilesList, 'ScriptFileHistoryNew', 'History');
@@ -1167,7 +1167,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.ModifyMRUMainFilesList(const AFilename: String;
+procedure TCompileForm.ModifyMRUMainFilesList(const AFilename: String;
   const AddNewItem: Boolean);
 begin
   { Load most recent items first, just in case they've changed }
@@ -1185,7 +1185,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.ReadMRUParametersList;
+procedure TCompileForm.ReadMRUParametersList;
 begin
   try
     ReadMRUList(FMRUParametersList, 'ParameterHistory', 'History');
@@ -1194,7 +1194,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.ModifyMRUParametersList(const AParameter: String;
+procedure TCompileForm.ModifyMRUParametersList(const AParameter: String;
   const AddNewItem: Boolean);
 begin
   { Load most recent items first, just in case they've changed }
@@ -1212,19 +1212,19 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.StatusMessage(const Kind: TStatusMessageKind; const S: String);
+procedure TCompileForm.StatusMessage(const Kind: TStatusMessageKind; const S: String);
 begin
   AddLines(CompilerOutputList, S, TObject(Kind), False, alpNone, 0);
   CompilerOutputList.Update;
 end;
 
-{ok}procedure TCompileForm.DebugLogMessage(const S: String);
+procedure TCompileForm.DebugLogMessage(const S: String);
 begin
   AddLines(DebugOutputList, S, nil, True, alpTimestamp, FDebugLogListTimestampsWidth);
   DebugOutputList.Update;
 end;
 
-{ok}procedure TCompileForm.DebugShowCallStack(const CallStack: String; const CallStackCount: Cardinal);
+procedure TCompileForm.DebugShowCallStack(const CallStack: String; const CallStackCount: Cardinal);
 begin
   DebugCallStackList.Clear;
   AddLines(DebugCallStackList, CallStack, nil, True, alpCountdown, FCallStackCount-1);
@@ -1247,7 +1247,7 @@ type
     Aborted: Boolean;
   end;
 
-{ok}function CompilerCallbackProc(Code: Integer; var Data: TCompilerCallbackData;
+function CompilerCallbackProc(Code: Integer; var Data: TCompilerCallbackData;
   AppData: Longint): Integer; stdcall;
 
   procedure DecodeIncludedFilenames(P: PChar; const IncludedFiles: TIncludedFiles);
@@ -1370,7 +1370,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.CompileFile(AFilename: String; const ReadFromFile: Boolean);
+procedure TCompileForm.CompileFile(AFilename: String; const ReadFromFile: Boolean);
 var
   SourcePath, S, Options: String;
   Params: TCompileScriptParamsEx;
@@ -1537,7 +1537,7 @@ begin
   FModifiedAnySinceLastCompileAndGo := False;
 end;
 
-{ok}procedure TCompileForm.SyncEditorOptions;
+procedure TCompileForm.SyncEditorOptions;
 const
   SquigglyStyles: array[Boolean] of Integer = (INDIC_HIDDEN, INDIC_SQUIGGLE);
 var
@@ -1567,7 +1567,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.FMenuClick(Sender: TObject);
+procedure TCompileForm.FMenuClick(Sender: TObject);
 
   function DoubleAmp(const S: String): String;
   var
@@ -1605,19 +1605,19 @@ begin
     end;
 end;
 
-{ok}procedure TCompileForm.FNewMainFileClick(Sender: TObject);
+procedure TCompileForm.FNewMainFileClick(Sender: TObject);
 begin
   if ConfirmCloseFile(True, False) then
     NewMainFile;
 end;
 
-{ok}procedure TCompileForm.FNewMainFileUserWizardClick(Sender: TObject);
+procedure TCompileForm.FNewMainFileUserWizardClick(Sender: TObject);
 begin
   if ConfirmCloseFile(True, False) then
     NewMainFileUsingWizard;
 end;
 
-{ok}procedure TCompileForm.ShowOpenMainFileDialog(const Examples: Boolean);
+procedure TCompileForm.ShowOpenMainFileDialog(const Examples: Boolean);
 var
   InitialDir, FileName: String;
 begin
@@ -1634,22 +1634,22 @@ begin
       OpenFile(FMainMemo, Filename, False);
 end;
 
-{ok}procedure TCompileForm.FOpenMainFileClick(Sender: TObject);
+procedure TCompileForm.FOpenMainFileClick(Sender: TObject);
 begin
   ShowOpenMainFileDialog(False);
 end;
 
-{ok}procedure TCompileForm.FSaveClick(Sender: TObject);
+procedure TCompileForm.FSaveClick(Sender: TObject);
 begin
   SaveFile(FActiveMemo, Sender = FSaveMainFileAs);
 end;
 
-{ok}procedure TCompileForm.FSaveEncodingItemClick(Sender: TObject);
+procedure TCompileForm.FSaveEncodingItemClick(Sender: TObject);
 begin
   FActiveMemo.SaveInUTF8Encoding := (Sender = FSaveEncodingUTF8);
 end;
 
-{ok}procedure TCompileForm.FMRUClick(Sender: TObject);
+procedure TCompileForm.FMRUClick(Sender: TObject);
 var
   I: Integer;
 begin
@@ -1661,12 +1661,12 @@ begin
       end;
 end;
 
-{ok}procedure TCompileForm.FExitClick(Sender: TObject);
+procedure TCompileForm.FExitClick(Sender: TObject);
 begin
   Close;
 end;
 
-{ok}procedure TCompileForm.EMenuClick(Sender: TObject);
+procedure TCompileForm.EMenuClick(Sender: TObject);
 var
   MemoHasFocus: Boolean;
 begin
@@ -1685,48 +1685,48 @@ begin
   ECompleteWord.Enabled := MemoHasFocus;
 end;
 
-{ok}procedure TCompileForm.EUndoClick(Sender: TObject);
+procedure TCompileForm.EUndoClick(Sender: TObject);
 begin
   FActiveMemo.Undo;
 end;
 
-{ok}procedure TCompileForm.ERedoClick(Sender: TObject);
+procedure TCompileForm.ERedoClick(Sender: TObject);
 begin
   FActiveMemo.Redo;
 end;
 
-{ok}procedure TCompileForm.ECutClick(Sender: TObject);
+procedure TCompileForm.ECutClick(Sender: TObject);
 begin
   FActiveMemo.CutToClipboard;
 end;
 
-{ok}procedure TCompileForm.ECopyClick(Sender: TObject);
+procedure TCompileForm.ECopyClick(Sender: TObject);
 begin
   FActiveMemo.CopyToClipboard;
 end;
 
-{ok}procedure TCompileForm.EPasteClick(Sender: TObject);
+procedure TCompileForm.EPasteClick(Sender: TObject);
 begin
   FActiveMemo.PasteFromClipboard;
 end;
 
-{ok}
+
 procedure TCompileForm.EDeleteClick(Sender: TObject);
 begin
   FActiveMemo.ClearSelection;
 end;
 
-{ok}procedure TCompileForm.ESelectAllClick(Sender: TObject);
+procedure TCompileForm.ESelectAllClick(Sender: TObject);
 begin
   FActiveMemo.SelectAll;
 end;
 
-{ok}procedure TCompileForm.ECompleteWordClick(Sender: TObject);
+procedure TCompileForm.ECompleteWordClick(Sender: TObject);
 begin
   InitiateAutoComplete(#0);
 end;
 
-{ok}procedure TCompileForm.VMenuClick(Sender: TObject);
+procedure TCompileForm.VMenuClick(Sender: TObject);
 begin
   VZoomIn.Enabled := (FActiveMemo.Zoom < 20);
   VZoomOut.Enabled := (FActiveMemo.Zoom > -10);
@@ -1739,7 +1739,7 @@ begin
   VDebugCallStack.Checked := StatusPanel.Visible and (OutputTabSet.TabIndex = tiDebugCallStack);
 end;
 
-{ok}procedure TCompileForm.SyncZoom;
+procedure TCompileForm.SyncZoom;
 var
   Memo: TCompScintEdit;
 begin
@@ -1750,7 +1750,7 @@ begin
       Memo.Zoom := FActiveMemo.Zoom;
 end;
 
-{ok}procedure TCompileForm.VZoomInClick(Sender: TObject);
+procedure TCompileForm.VZoomInClick(Sender: TObject);
 var
   Memo: TCompScintEdit;
 begin
@@ -1759,7 +1759,7 @@ begin
     Memo.ZoomIn;
 end;
 
-{ok}procedure TCompileForm.VZoomOutClick(Sender: TObject);
+procedure TCompileForm.VZoomOutClick(Sender: TObject);
 var
   Memo: TCompScintEdit;
 begin
@@ -1768,7 +1768,7 @@ begin
     Memo.ZoomOut;
 end;
 
-{ok}procedure TCompileForm.VZoomResetClick(Sender: TObject);
+procedure TCompileForm.VZoomResetClick(Sender: TObject);
 var
   Memo: TCompScintEdit;
 begin
@@ -1776,17 +1776,17 @@ begin
     Memo.Zoom := 0;
 end;
 
-{ok}procedure TCompileForm.VToolbarClick(Sender: TObject);
+procedure TCompileForm.VToolbarClick(Sender: TObject);
 begin
   Toolbar.Visible := not Toolbar.Visible;
 end;
 
-{ok}procedure TCompileForm.VStatusBarClick(Sender: TObject);
+procedure TCompileForm.VStatusBarClick(Sender: TObject);
 begin
   StatusBar.Visible := not StatusBar.Visible;
 end;
 
-{ok}procedure TCompileForm.SetStatusPanelVisible(const AVisible: Boolean);
+procedure TCompileForm.SetStatusPanelVisible(const AVisible: Boolean);
 var
   CaretWasInView: Boolean;
 begin
@@ -1811,41 +1811,41 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.VHideClick(Sender: TObject);
+procedure TCompileForm.VHideClick(Sender: TObject);
 begin
   SetStatusPanelVisible(False);
 end;
 
-{ok}procedure TCompileForm.VCompilerOutputClick(Sender: TObject);
+procedure TCompileForm.VCompilerOutputClick(Sender: TObject);
 begin
   OutputTabSet.TabIndex := tiCompilerOutput;
   SetStatusPanelVisible(True);
 end;
 
-{ok}procedure TCompileForm.VDebugOutputClick(Sender: TObject);
+procedure TCompileForm.VDebugOutputClick(Sender: TObject);
 begin
   OutputTabSet.TabIndex := tiDebugOutput;
   SetStatusPanelVisible(True);
 end;
 
-{ok}procedure TCompileForm.VDebugCallStackClick(Sender: TObject);
+procedure TCompileForm.VDebugCallStackClick(Sender: TObject);
 begin
   OutputTabSet.TabIndex := tiDebugCallStack;
   SetStatusPanelVisible(True);
 end;
 
-{ok}procedure TCompileForm.BMenuClick(Sender: TObject);
+procedure TCompileForm.BMenuClick(Sender: TObject);
 begin
   BLowPriority.Checked := FOptions.LowPriorityDuringCompile;
   BOpenOutputFolder.Enabled := (FCompiledExe <> '');
 end;
 
-{ok}procedure TCompileForm.BCompileClick(Sender: TObject);
+procedure TCompileForm.BCompileClick(Sender: TObject);
 begin
   CompileFile('', False);
 end;
 
-{ok}procedure TCompileForm.BStopCompileClick(Sender: TObject);
+procedure TCompileForm.BStopCompileClick(Sender: TObject);
 begin
   SetAppTaskbarProgressState(tpsPaused);
   try
@@ -1857,7 +1857,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.BLowPriorityClick(Sender: TObject);
+procedure TCompileForm.BLowPriorityClick(Sender: TObject);
 begin
   FOptions.LowPriorityDuringCompile := not FOptions.LowPriorityDuringCompile;
   { If a compile is already in progress, change the priority now }
@@ -1865,7 +1865,7 @@ begin
     SetLowPriority(FOptions.LowPriorityDuringCompile, FSavePriorityClass);
 end;
 
-{ok}procedure TCompileForm.BOpenOutputFolderClick(Sender: TObject);
+procedure TCompileForm.BOpenOutputFolderClick(Sender: TObject);
 var
   Dir: String;
 begin
@@ -1874,13 +1874,13 @@ begin
     PChar(Format('/select,"%s"', [FCompiledExe])), PChar(Dir), SW_SHOW);
 end;
 
-{ok}procedure TCompileForm.HMenuClick(Sender: TObject);
+procedure TCompileForm.HMenuClick(Sender: TObject);
 begin
   HISPPDoc.Visible := NewFileExists(PathExtractPath(NewParamStr(0)) + 'ispp.chm');
   HISPPSep.Visible := HISPPDoc.Visible;
 end;
 
-{ok}procedure TCompileForm.HDocClick(Sender: TObject);
+procedure TCompileForm.HDocClick(Sender: TObject);
 var
   HelpFile: String;
 begin
@@ -1889,7 +1889,7 @@ begin
     HtmlHelp(GetDesktopWindow, PChar(HelpFile), HH_DISPLAY_TOPIC, 0);
 end;
 
-{ok}procedure TCompileForm.MemoKeyDown(Sender: TObject; var Key: Word;
+procedure TCompileForm.MemoKeyDown(Sender: TObject; var Key: Word;
   Shift: TShiftState);
 var
   S, HelpFile: String;
@@ -1915,7 +1915,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.MemoKeyPress(Sender: TObject; var Key: Char);
+procedure TCompileForm.MemoKeyPress(Sender: TObject; var Key: Char);
 begin
   if (Key = ' ') and (GetKeyState(VK_CONTROL) < 0) then begin
     InitiateAutoComplete(#0);
@@ -1923,53 +1923,53 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.HExamplesClick(Sender: TObject);
+procedure TCompileForm.HExamplesClick(Sender: TObject);
 begin
   ShellExecute(Application.Handle, 'open',
     PChar(PathExtractPath(NewParamStr(0)) + 'Examples'), nil, nil, SW_SHOW);
 end;
 
-{ok}procedure TCompileForm.HFaqClick(Sender: TObject);
+procedure TCompileForm.HFaqClick(Sender: TObject);
 begin
   ShellExecute(Application.Handle, 'open',
     PChar(PathExtractPath(NewParamStr(0)) + 'isfaq.url'), nil, nil, SW_SHOW);
 end;
 
-{ok}procedure TCompileForm.HWhatsNewClick(Sender: TObject);
+procedure TCompileForm.HWhatsNewClick(Sender: TObject);
 begin
   ShellExecute(Application.Handle, 'open',
     PChar(PathExtractPath(NewParamStr(0)) + 'whatsnew.htm'), nil, nil, SW_SHOW);
 end;
 
-{ok}procedure TCompileForm.HWebsiteClick(Sender: TObject);
+procedure TCompileForm.HWebsiteClick(Sender: TObject);
 begin
   ShellExecute(Application.Handle, 'open', 'https://jrsoftware.org/isinfo.php', nil,
     nil, SW_SHOW);
 end;
 
-{ok}procedure TCompileForm.HMailingListClick(Sender: TObject);
+procedure TCompileForm.HMailingListClick(Sender: TObject);
 begin
   OpenMailingListSite;
 end;
 
-{ok}procedure TCompileForm.HPSWebsiteClick(Sender: TObject);
+procedure TCompileForm.HPSWebsiteClick(Sender: TObject);
 begin
   ShellExecute(Application.Handle, 'open', 'http://www.remobjects.com/ps', nil,
     nil, SW_SHOW);
 end;
 
-{ok}procedure TCompileForm.HISPPDocClick(Sender: TObject);
+procedure TCompileForm.HISPPDocClick(Sender: TObject);
 begin
   if Assigned(HtmlHelp) then
     HtmlHelp(GetDesktopWindow, PChar(GetHelpFile + '::/hh_isppredirect.xhtm'), HH_DISPLAY_TOPIC, 0);
 end;
 
-{ok}procedure TCompileForm.HDonateClick(Sender: TObject);
+procedure TCompileForm.HDonateClick(Sender: TObject);
 begin
   OpenDonateSite;
 end;
 
-{ok}procedure TCompileForm.HAboutClick(Sender: TObject);
+procedure TCompileForm.HAboutClick(Sender: TObject);
 var
   S: String;
 begin
@@ -1992,7 +1992,7 @@ begin
   MsgBox(S, 'About ' + FCompilerVersion.Title, mbInformation, MB_OK);
 end;
 
-{ok}procedure TCompileForm.WMStartCommandLineCompile(var Message: TMessage);
+procedure TCompileForm.WMStartCommandLineCompile(var Message: TMessage);
 var
   Code: Integer;
 begin
@@ -2010,7 +2010,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.WMStartCommandLineWizard(var Message: TMessage);
+procedure TCompileForm.WMStartCommandLineWizard(var Message: TMessage);
 var
   Code: Integer;
 begin
@@ -2027,7 +2027,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.WMStartNormally(var Message: TMessage);
+procedure TCompileForm.WMStartNormally(var Message: TMessage);
 
   procedure ShowStartupForm;
   var
@@ -2076,7 +2076,7 @@ begin
     OpenFile(FMainMemo, CommandLineFilename, False);
 end;
 
-{ok}procedure TCompileForm.MemosTabSetClick(Sender: TObject);
+procedure TCompileForm.MemosTabSetClick(Sender: TObject);
 var
   Memo: TCompScintEdit;
   I: Integer;
@@ -2096,7 +2096,7 @@ begin
   UpdateModifiedPanel;
 end;
 
-{ok}procedure TCompileForm.InitializeFindText(Dlg: TFindDialog);
+procedure TCompileForm.InitializeFindText(Dlg: TFindDialog);
 var
   S: String;
 begin
@@ -2107,7 +2107,7 @@ begin
     Dlg.FindText := FLastFindText;
 end;
 
-{ok}procedure TCompileForm.EFindClick(Sender: TObject);
+procedure TCompileForm.EFindClick(Sender: TObject);
 begin
   ReplaceDialog.CloseDialog;
   if FindDialog.Handle = 0 then
@@ -2115,7 +2115,7 @@ begin
   FindDialog.Execute;
 end;
 
-{ok}procedure TCompileForm.EFindNextClick(Sender: TObject);
+procedure TCompileForm.EFindNextClick(Sender: TObject);
 begin
   if FLastFindText = '' then
     EFindClick(Sender)
@@ -2123,7 +2123,7 @@ begin
     FindNext;
 end;
 
-{ok}procedure TCompileForm.FindNext;
+procedure TCompileForm.FindNext;
 var
   StartPos, EndPos: Integer;
   Range: TScintRange;
@@ -2144,7 +2144,7 @@ begin
       mbInformation, MB_OK);
 end;
 
-{ok}procedure TCompileForm.FindDialogFind(Sender: TObject);
+procedure TCompileForm.FindDialogFind(Sender: TObject);
 begin
   { this event handler is shared between FindDialog & ReplaceDialog }
   with Sender as TFindDialog do begin
@@ -2156,7 +2156,7 @@ begin
   FindNext;
 end;
 
-{ok}procedure TCompileForm.EReplaceClick(Sender: TObject);
+procedure TCompileForm.EReplaceClick(Sender: TObject);
 begin
   FindDialog.CloseDialog;
   if ReplaceDialog.Handle = 0 then begin
@@ -2166,7 +2166,7 @@ begin
   ReplaceDialog.Execute;
 end;
 
-{ok}procedure TCompileForm.ReplaceDialogReplace(Sender: TObject);
+procedure TCompileForm.ReplaceDialogReplace(Sender: TObject);
 var
   ReplaceCount, Pos: Integer;
   Range, NewRange: TScintRange;
@@ -2203,7 +2203,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.UpdateStatusPanelHeight(H: Integer);
+procedure TCompileForm.UpdateStatusPanelHeight(H: Integer);
 var
   MinHeight, MaxHeight: Integer;
 begin
@@ -2214,7 +2214,7 @@ begin
   StatusPanel.Height := H;
 end;
 
-{ok}procedure TCompileForm.UpdateTabSetListsItemHeightAndDebugTimeWidth;
+procedure TCompileForm.UpdateTabSetListsItemHeightAndDebugTimeWidth;
 begin
   CompilerOutputList.Canvas.Font.Assign(CompilerOutputList.Font);
   CompilerOutputList.ItemHeight := CompilerOutputList.Canvas.TextHeight('0');
@@ -2227,7 +2227,7 @@ begin
   DebugCallStackList.ItemHeight := DebugCallStackList.Canvas.TextHeight('0');
 end;
 
-{ok}procedure TCompileForm.SplitPanelMouseMove(Sender: TObject;
+procedure TCompileForm.SplitPanelMouseMove(Sender: TObject;
   Shift: TShiftState; X, Y: Integer);
 begin
   if (ssLeft in Shift) and StatusPanel.Visible then begin
@@ -2237,19 +2237,19 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.TAddRemoveProgramsClick(Sender: TObject);
+procedure TCompileForm.TAddRemoveProgramsClick(Sender: TObject);
 begin
   StartAddRemovePrograms;
 end;
 
-{ok}procedure TCompileForm.TGenerateGUIDClick(Sender: TObject);
+procedure TCompileForm.TGenerateGUIDClick(Sender: TObject);
 begin
   if MsgBox('The generated GUID will be inserted into the editor at the cursor position. Continue?',
      SCompilerFormCaption, mbConfirmation, MB_YESNO) = IDYES then
     FActiveMemo.SelText := GenerateGuid;
 end;
 
-{ok}procedure TCompileForm.TInsertMsgBoxClick(Sender: TObject);
+procedure TCompileForm.TInsertMsgBoxClick(Sender: TObject);
 var
   MsgBoxForm: TMBDForm;
 begin
@@ -2262,7 +2262,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.TSignToolsClick(Sender: TObject);
+procedure TCompileForm.TSignToolsClick(Sender: TObject);
 var
   SignToolsForm: TSignToolsForm;
   Ini: TConfigIniFile;
@@ -2399,7 +2399,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.MoveMainMemoCaret(const LineNumber: Integer;
+procedure TCompileForm.MoveMainMemoCaret(const LineNumber: Integer;
   const AlwaysResetColumn: Boolean);
 var
   Pos: Integer;
@@ -2418,7 +2418,7 @@ begin
   MemosTabSet.TabIndex := FMemos.IndexOf(FMainMemo);
 end;
 
-{ok}procedure TCompileForm.SetMainMemoErrorLine(ALine: Integer);
+procedure TCompileForm.SetMainMemoErrorLine(ALine: Integer);
 var
   OldLine: Integer;
 begin
@@ -2434,7 +2434,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.SetMainMemoStepLine(ALine: Integer);
+procedure TCompileForm.SetMainMemoStepLine(ALine: Integer);
 var
   OldLine: Integer;
 begin
@@ -2448,20 +2448,20 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.HideMainMemoError;
+procedure TCompileForm.HideMainMemoError;
 begin
   SetMainMemoErrorLine(-1);
   if not FCompiling then
     StatusBar.Panels[spExtraStatus].Text := '';
 end;
 
-{ok}procedure TCompileForm.UpdateCaretPosPanel;
+procedure TCompileForm.UpdateCaretPosPanel;
 begin
   StatusBar.Panels[spCaretPos].Text := Format('%4d:%4d', [FActiveMemo.CaretLine + 1,
     FActiveMemo.CaretColumnExpanded + 1]);
 end;
 
-{ok}procedure TCompileForm.UpdateEditModePanel;
+procedure TCompileForm.UpdateEditModePanel;
 const
   InsertText: array[Boolean] of String = ('Overwrite', 'Insert');
 begin
@@ -2471,7 +2471,7 @@ begin
     StatusBar.Panels[spEditMode].Text := InsertText[FActiveMemo.InsertMode];
 end;
 
-{ok}procedure TCompileForm.UpdateModifiedPanel;
+procedure TCompileForm.UpdateModifiedPanel;
 begin
   if FActiveMemo.Modified then
     StatusBar.Panels[spModified].Text := 'Modified'
@@ -2540,7 +2540,7 @@ begin
   UpdateBevel1;
 end;
 
-{ok}procedure TCompileForm.MemoUpdateUI(Sender: TObject);
+procedure TCompileForm.MemoUpdateUI(Sender: TObject);
 
   procedure UpdatePendingSquiggly;
   var
@@ -2611,7 +2611,7 @@ begin
     UpdateEditModePanel;
 end;
 
-{ok}procedure TCompileForm.MemoModifiedChange(Sender: TObject);
+procedure TCompileForm.MemoModifiedChange(Sender: TObject);
 begin
   if Sender = FActiveMemo then
     UpdateModifiedPanel;
@@ -2661,7 +2661,7 @@ begin
   TCompScintEdit(Sender).ReportCaretPositionToStyler := True;
 end;
 
-{ok}procedure TCompileForm.InitiateAutoComplete(const Key: AnsiChar);
+procedure TCompileForm.InitiateAutoComplete(const Key: AnsiChar);
 var
   CaretPos, Line, LinePos, WordStartPos, WordEndPos, CharsBefore, I,
     LangNamePos: Integer;
@@ -2741,7 +2741,7 @@ begin
   FActiveMemo.ShowAutoComplete(CharsBefore, WordList);
 end;
 
-{ok}procedure TCompileForm.MemoCharAdded(Sender: TObject; Ch: AnsiChar);
+procedure TCompileForm.MemoCharAdded(Sender: TObject; Ch: AnsiChar);
 
   function LineIsBlank(const Line: Integer): Boolean;
   var
@@ -2941,7 +2941,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.MainMemoDropFiles(Sender: TObject; X, Y: Integer;
+procedure TCompileForm.MainMemoDropFiles(Sender: TObject; X, Y: Integer;
   AFiles: TStrings);
 begin
   if (AFiles.Count > 0) and ConfirmCloseFile(True, True) then begin
@@ -2951,7 +2951,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.StatusBarResize(Sender: TObject);
+procedure TCompileForm.StatusBarResize(Sender: TObject);
 begin
   { Without this, on Windows XP with themes, the status bar's size grip gets
     corrupted as the form is resized }
@@ -2959,7 +2959,7 @@ begin
     InvalidateRect(StatusBar.Handle, nil, True);
 end;
 
-{ok}procedure TCompileForm.WMDebuggerQueryVersion(var Message: TMessage);
+procedure TCompileForm.WMDebuggerQueryVersion(var Message: TMessage);
 begin
   Message.Result := FCompilerVersion.BinVersion;
 end;
@@ -2990,7 +2990,7 @@ begin
   UpdateRunMenu;
 end;
 
-{ok}procedure TCompileForm.WMDebuggerGoodbye(var Message: TMessage);
+procedure TCompileForm.WMDebuggerGoodbye(var Message: TMessage);
 begin
   ReplyMessage(0);
   DebuggingStopped(True);
@@ -3379,7 +3379,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.UpdateTheme;
+procedure TCompileForm.UpdateTheme;
 
   procedure SetControlTheme(const WinControl: TWinControl);
   begin
@@ -3430,7 +3430,7 @@ begin
   SetControlTheme(DebugCallStackList);
 end;
 
-{ok}procedure TCompileForm.UpdateThemeData(const Close, Open: Boolean);
+procedure TCompileForm.UpdateThemeData(const Close, Open: Boolean);
 begin
   if Close then begin
     if FProgressThemeData <> 0 then begin
@@ -3536,7 +3536,7 @@ begin
   DebugLogMessage('*** ' + DebugTargetStrings[FDebugTarget] + ' started');
 end;
 
-{ok}procedure TCompileForm.CompileIfNecessary;
+procedure TCompileForm.CompileIfNecessary;
 
   function UnopenedIncludedFileModifiedSinceLastCompile: Boolean;
   var
@@ -3573,7 +3573,7 @@ begin
     CompileFile('', False);
 end;
 
-{ok}procedure TCompileForm.Go(AStepMode: TStepMode);
+procedure TCompileForm.Go(AStepMode: TStepMode);
 begin
   CompileIfNecessary;
   FStepMode := AStepMode;
@@ -3598,7 +3598,7 @@ begin
     StartProcess;
 end;
 
-{ok}function TCompileForm.EvaluateConstant(const S: String;
+function TCompileForm.EvaluateConstant(const S: String;
   var Output: String): Integer;
 begin
   FReplyString := '';
@@ -3618,12 +3618,12 @@ begin
     Output := FReplyString;
 end;
 
-{ok}procedure TCompileForm.RRunClick(Sender: TObject);
+procedure TCompileForm.RRunClick(Sender: TObject);
 begin
   Go(smRun);
 end;
 
-{ok}procedure TCompileForm.RParametersClick(Sender: TObject);
+procedure TCompileForm.RParametersClick(Sender: TObject);
 begin
   ReadMRUParametersList;
   InputQueryCombo('Run Parameters', 'Command line parameters for ' + DebugTargetStrings[dtSetup] +
@@ -3632,7 +3632,7 @@ begin
     ModifyMRUParametersList(FRunParameters, True);
 end;
 
-{ok}procedure TCompileForm.RPauseClick(Sender: TObject);
+procedure TCompileForm.RPauseClick(Sender: TObject);
 begin
   if FDebugging and not FPaused then begin
     if FStepMode <> smStepInto then begin
@@ -3645,7 +3645,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.RRunToCursorClick(Sender: TObject);
+procedure TCompileForm.RRunToCursorClick(Sender: TObject);
 
   function GetDebugEntryFromMainFileLineNumber(LineNumber: Integer;
     var DebugEntry: TDebugEntry): Boolean;
@@ -3672,17 +3672,17 @@ begin
   Go(smRunToCursor);
 end;
 
-{ok}procedure TCompileForm.RStepIntoClick(Sender: TObject);
+procedure TCompileForm.RStepIntoClick(Sender: TObject);
 begin
   Go(smStepInto);
 end;
 
-{ok}procedure TCompileForm.RStepOverClick(Sender: TObject);
+procedure TCompileForm.RStepOverClick(Sender: TObject);
 begin
   Go(smStepOver);
 end;
 
-{ok}procedure TCompileForm.RTerminateClick(Sender: TObject);
+procedure TCompileForm.RTerminateClick(Sender: TObject);
 var
   S, Dir: String;
 begin
@@ -3730,7 +3730,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.CheckIfRunningTimerTimer(Sender: TObject);
+procedure TCompileForm.CheckIfRunningTimerTimer(Sender: TObject);
 begin
   { In cases of normal Setup termination, we receive a WM_Debugger_Goodbye
     message. But in case we don't get that, use a timer to periodically check
@@ -3738,7 +3738,7 @@ begin
   CheckIfTerminated;
 end;
 
-{ok}procedure TCompileForm.PListCopyClick(Sender: TObject);
+procedure TCompileForm.PListCopyClick(Sender: TObject);
 var
   ListBox: TListBox;
   Text: String;
@@ -3763,7 +3763,7 @@ begin
   Clipboard.AsText := Text;
 end;
 
-{ok}procedure TCompileForm.PListSelectAllClick(Sender: TObject);
+procedure TCompileForm.PListSelectAllClick(Sender: TObject);
 var
   ListBox: TListBox;
   I: Integer;
@@ -3783,7 +3783,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.AppOnIdle(Sender: TObject; var Done: Boolean);
+procedure TCompileForm.AppOnIdle(Sender: TObject; var Done: Boolean);
 begin
   { For an explanation of this, see the comment where HandleMessage is called }
   if FCompiling then
@@ -3792,7 +3792,7 @@ begin
   FBecameIdle := True;
 end;
 
-{ok}procedure TCompileForm.EGotoClick(Sender: TObject);
+procedure TCompileForm.EGotoClick(Sender: TObject);
 var
   S: String;
   L: Integer;
@@ -3805,7 +3805,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.StatusBarDrawPanel(StatusBar: TStatusBar;
+procedure TCompileForm.StatusBarDrawPanel(StatusBar: TStatusBar;
   Panel: TStatusPanel; const Rect: TRect);
 var
   R, BR: TRect;
@@ -3847,7 +3847,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.InvalidateStatusPanel(const Index: Integer);
+procedure TCompileForm.InvalidateStatusPanel(const Index: Integer);
 var
   R: TRect;
 begin
@@ -3858,7 +3858,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.UpdateCompileStatusPanels(const AProgress,
+procedure TCompileForm.UpdateCompileStatusPanels(const AProgress,
   AProgressMax: Cardinal; const ASecondsRemaining: Integer;
   const ABytesCompressedPerSecond: Cardinal);
 var
@@ -3891,7 +3891,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.WMSettingChange(var Message: TMessage);
+procedure TCompileForm.WMSettingChange(var Message: TMessage);
 begin
   if (FTheme.Typ <> ttClassic) and (Win32MajorVersion >= 10) and (Message.LParam <> 0) and (StrIComp(PChar(Message.LParam), 'ImmersiveColorSet') = 0) then begin
     FOptions.ThemeType := GetDefaultThemeType;
@@ -3899,14 +3899,14 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.WMThemeChanged(var Message: TMessage);
+procedure TCompileForm.WMThemeChanged(var Message: TMessage);
 begin
   { Don't Run to Cursor into this function, it will interrupt up the theme change }
   UpdateThemeData(True, True);
   inherited;
 end;
 
-{ok}procedure TCompileForm.RTargetClick(Sender: TObject);
+procedure TCompileForm.RTargetClick(Sender: TObject);
 var
   NewTarget: TDebugTarget;
 begin
@@ -3921,7 +3921,7 @@ begin
   UpdateTargetMenu;
 end;
 
-procedure TCompileForm.AppOnActivate(Sender: TObject);
+{todo}procedure TCompileForm.AppOnActivate(Sender: TObject);
 const
   ReloadMessages: array[Boolean] of String = (
     'The file has been modified outside of the source editor.' + SNewLine2 +
@@ -3963,7 +3963,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.CompilerOutputListDrawItem(Control: TWinControl;
+procedure TCompileForm.CompilerOutputListDrawItem(Control: TWinControl;
   Index: Integer; Rect: TRect; State: TOwnerDrawState);
 const
   ThemeColors: array [TStatusMessageKind] of TThemeColor = (tcGreen, tcFore, tcOrange, tcRed);
@@ -3984,7 +3984,7 @@ begin
   Canvas.TextOut(Rect.Left, Rect.Top, S);
 end;
 
-{ok}procedure TCompileForm.DebugOutputListDrawItem(Control: TWinControl;
+procedure TCompileForm.DebugOutputListDrawItem(Control: TWinControl;
   Index: Integer; Rect: TRect; State: TOwnerDrawState);
 var
   Canvas: TCanvas;
@@ -4008,7 +4008,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.DebugCallStackListDrawItem(Control: TWinControl; Index: Integer; Rect: TRect;
+procedure TCompileForm.DebugCallStackListDrawItem(Control: TWinControl; Index: Integer; Rect: TRect;
   State: TOwnerDrawState);
 var
   Canvas: TCanvas;
@@ -4022,7 +4022,7 @@ begin
   Canvas.TextOut(Rect.Left, Rect.Top, S);
 end;
 
-{ok}procedure TCompileForm.OutputTabSetClick(Sender: TObject);
+procedure TCompileForm.OutputTabSetClick(Sender: TObject);
 begin
   case OutputTabSet.TabIndex of
     tiCompilerOutput:
@@ -4049,7 +4049,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.MainMemoToggleBreakPoint(Line: Integer);
+procedure TCompileForm.MainMemoToggleBreakPoint(Line: Integer);
 var
   I: Integer;
 begin
@@ -4061,14 +4061,14 @@ begin
   UpdateMainMemoLineMarkers(Line);
 end;
 
-{ok}procedure TCompileForm.MainMemoMarginClick(Sender: TObject; MarginNumber: Integer;
+procedure TCompileForm.MainMemoMarginClick(Sender: TObject; MarginNumber: Integer;
   Line: Integer);
 begin
   if MarginNumber = 1 then
     MainMemoToggleBreakPoint(Line);
 end;
 
-{ok}procedure TCompileForm.MainMemoLinesInserted(FirstLine, Count: integer);
+procedure TCompileForm.MainMemoLinesInserted(FirstLine, Count: integer);
 var
   I, Line: Integer;
 begin
@@ -4105,7 +4105,7 @@ begin
   end;
 end;
 
-{ok}procedure TCompileForm.MainMemoLinesDeleted(FirstLine, Count,
+procedure TCompileForm.MainMemoLinesDeleted(FirstLine, Count,
   FirstAffectedLine: Integer);
 var
   I, Line: Integer;
@@ -4170,7 +4170,7 @@ begin
   UpdateMainMemoLineMarkers(FirstAffectedLine);
 end;
 
-{ok}procedure TCompileForm.UpdateMainMemoLineMarkers(const Line: Integer);
+procedure TCompileForm.UpdateMainMemoLineMarkers(const Line: Integer);
 var
   NewMarker: Integer;
 begin
@@ -4213,7 +4213,7 @@ begin
     FMainMemo.AddMarker(Line, mmLineBreakpointBad);
 end;
 
-{ok}procedure TCompileForm.UpdateAllMainMemoLineMarkers;
+procedure TCompileForm.UpdateAllMainMemoLineMarkers;
 var
   Line: Integer;
 begin
@@ -4221,22 +4221,22 @@ begin
     UpdateMainMemoLineMarkers(Line);
 end;
 
-{ok}procedure TCompileForm.UpdateBevel1;
+procedure TCompileForm.UpdateBevel1;
 begin
   Bevel1.Visible := (FTheme.Colors[tcMarginBack] = ToolBarPanel.Color) and not MemosTabSet.Visible;
 end;
 
-{ok}procedure TCompileForm.RToggleBreakPointClick(Sender: TObject);
+procedure TCompileForm.RToggleBreakPointClick(Sender: TObject);
 begin
   MainMemoToggleBreakPoint(FMainMemo.CaretLine);
 end;
 
-{ok}function TCompileForm.ToCurrentPPI(const XY: Integer): Integer;
+function TCompileForm.ToCurrentPPI(const XY: Integer): Integer;
 begin
   Result := MulDiv(XY, CurrentPPI, 96);
 end;
 
-{ok}function TCompileForm.FromCurrentPPI(const XY: Integer): Integer;
+function TCompileForm.FromCurrentPPI(const XY: Integer): Integer;
 begin
   Result := MulDiv(XY, 96, CurrentPPI);
 end;

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -2497,8 +2497,10 @@ begin
           IncludedFile := FIncludedFiles[I];
           IncludedFile.Memo := FMemos[NextMemoIndex];
           try
-            if PathCompare(IncludedFile.Memo.Filename, IncludedFile.Filename) <> 0 then begin
-              OpenFile(IncludedFile.Memo, IncludedFile.Filename, False);
+            if (PathCompare(IncludedFile.Memo.Filename, IncludedFile.Filename) <> 0) or
+               not IncludedFile.HasLastWriteTime or
+               (CompareFileTime(IncludedFile.Memo.FileLastWriteTime, IncludedFile.LastWriteTime) <> 0) then begin
+              OpenFile(IncludedFile.Memo, IncludedFile.Filename, False); { Also updates FileLastWriteTime }
               IncludedFile.Memo.Filename := IncludedFile.Filename;
             end;
             NewTabs.Add(PathExtractName(IncludedFile.Filename));

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -441,7 +441,7 @@ type
     procedure WMDebuggerHello(var Message: TMessage); message WM_Debugger_Hello;
     procedure WMDebuggerGoodbye(var Message: TMessage); message WM_Debugger_Goodbye;
     procedure WMDebuggerQueryVersion(var Message: TMessage); message WM_Debugger_QueryVersion;
-    function GetLineNumberFromEntry(Kind, Index: Integer): Integer;
+    function GetMainFileLineNumberFromEntry(Kind, Index: Integer): Integer;
     procedure DebuggerStepped(var Message: TMessage; const Intermediate: Boolean);
     procedure WMDebuggerStepped(var Message: TMessage); message WM_Debugger_Stepped;
     procedure WMDebuggerSteppedIntermediate(var Message: TMessage); message WM_Debugger_SteppedIntermediate;
@@ -3061,7 +3061,7 @@ begin
   DebuggingStopped(True);
 end;
 
-function TCompileForm.GetLineNumberFromEntry(Kind, Index: Integer): Integer;
+function TCompileForm.GetMainFileLineNumberFromEntry(Kind, Index: Integer): Integer;
 var
   I: Integer;
 begin
@@ -3100,7 +3100,7 @@ procedure TCompileForm.DebuggerStepped(var Message: TMessage; const Intermediate
 var
   LineNumber: Integer;
 begin
-  LineNumber := GetLineNumberFromEntry(Message.WParam, Message.LParam);
+  LineNumber := GetMainFileLineNumberFromEntry(Message.WParam, Message.LParam);
   if LineNumber < 0 then
     Exit;
 
@@ -3143,7 +3143,7 @@ var
   LineNumber: Integer;
 begin
   if FOptions.PauseOnDebuggerExceptions then begin
-    LineNumber := GetLineNumberFromEntry(Message.WParam, Message.LParam);
+    LineNumber := GetMainFileLineNumberFromEntry(Message.WParam, Message.LParam);
 
     if (LineNumber >= 0) then begin
       MoveCaretAndActivateMemo(FMainMemo, LineNumber, True);

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -134,7 +134,7 @@ type
     N15: TMenuItem;
     RTargetSetup: TMenuItem;
     RTargetUninstall: TMenuItem;
-    TabSet: TNewTabSet;
+    OutputTabSet: TNewTabSet;
     DebugOutputList: TListBox;
     VDebugOutput: TMenuItem;
     VHide: TMenuItem;
@@ -246,7 +246,7 @@ type
     procedure RTargetClick(Sender: TObject);
     procedure DebugOutputListDrawItem(Control: TWinControl; Index: Integer;
       Rect: TRect; State: TOwnerDrawState);
-    procedure TabSetClick(Sender: TObject);
+    procedure OutputTabSetClick(Sender: TObject);
     procedure VHideClick(Sender: TObject);
     procedure VDebugOutputClick(Sender: TObject);
     procedure FormResize(Sender: TObject);
@@ -500,7 +500,7 @@ const
   spCompileProgress = 4;
   spExtraStatus = 5;
 
-  { Tab set indexes }
+  { Output tab set indexes }
   tiCompilerOutput = 0;
   tiDebugOutput = 1;
   tiDebugCallStack = 2;
@@ -870,7 +870,7 @@ constructor TCompileForm.Create(AOwner: TComponent);
         current form height, which hasn't been finalized yet }
 
       StatusPanel.Height := ToCurrentPPI(Ini.ReadInteger('State', 'StatusPanelHeight',
-        (10 * FromCurrentPPI(DebugOutputList.ItemHeight) + 4) + FromCurrentPPI(TabSet.Height)));
+        (10 * FromCurrentPPI(DebugOutputList.ItemHeight) + 4) + FromCurrentPPI(OutputTabSet.Height)));
     finally
       Ini.Free;
     end;
@@ -1105,7 +1105,7 @@ begin
     if ActiveControl <> Memo then
       ActiveControl := Memo
     else if StatusPanel.Visible then begin
-      case TabSet.TabIndex of
+      case OutputTabSet.TabIndex of
         tiCompilerOutput: ActiveControl := CompilerOutputList;
         tiDebugOutput: ActiveControl := DebugOutputList;
         tiDebugCallStack: ActiveControl := DebugCallStackList;
@@ -1819,7 +1819,7 @@ begin
     SendMessage(DebugOutputList.Handle, LB_SETHORIZONTALEXTENT, 0, 0);
     DebugCallStackList.Clear;
     SendMessage(DebugCallStackList.Handle, LB_SETHORIZONTALEXTENT, 0, 0);
-    TabSet.TabIndex := tiCompilerOutput;
+    OutputTabSet.TabIndex := tiCompilerOutput;
     SetStatusPanelVisible(True);
 
     if AFilename <> '' then
@@ -2133,9 +2133,9 @@ begin
   VToolbar.Checked := Toolbar.Visible;
   VStatusBar.Checked := StatusBar.Visible;
   VHide.Checked := not StatusPanel.Visible;
-  VCompilerOutput.Checked := StatusPanel.Visible and (TabSet.TabIndex = tiCompilerOutput);
-  VDebugOutput.Checked := StatusPanel.Visible and (TabSet.TabIndex = tiDebugOutput);
-  VDebugCallStack.Checked := StatusPanel.Visible and (TabSet.TabIndex = tiDebugCallStack);
+  VCompilerOutput.Checked := StatusPanel.Visible and (OutputTabSet.TabIndex = tiCompilerOutput);
+  VDebugOutput.Checked := StatusPanel.Visible and (OutputTabSet.TabIndex = tiDebugOutput);
+  VDebugCallStack.Checked := StatusPanel.Visible and (OutputTabSet.TabIndex = tiDebugCallStack);
 end;
 
 procedure TCompileForm.VZoomInClick(Sender: TObject);
@@ -2195,19 +2195,19 @@ end;
 
 procedure TCompileForm.VCompilerOutputClick(Sender: TObject);
 begin
-  TabSet.TabIndex := tiCompilerOutput;
+  OutputTabSet.TabIndex := tiCompilerOutput;
   SetStatusPanelVisible(True);
 end;
 
 procedure TCompileForm.VDebugOutputClick(Sender: TObject);
 begin
-  TabSet.TabIndex := tiDebugOutput;
+  OutputTabSet.TabIndex := tiDebugOutput;
   SetStatusPanelVisible(True);
 end;
 
 procedure TCompileForm.VDebugCallStackClick(Sender: TObject);
 begin
-  TabSet.TabIndex := tiDebugCallStack;
+  OutputTabSet.TabIndex := tiDebugCallStack;
   SetStatusPanelVisible(True);
 end;
 
@@ -2590,7 +2590,7 @@ procedure TCompileForm.UpdateStatusPanelHeight(H: Integer);
 var
   MinHeight, MaxHeight: Integer;
 begin
-  MinHeight := (3 * DebugOutputList.ItemHeight + ToCurrentPPI(4)) + TabSet.Height;
+  MinHeight := (3 * DebugOutputList.ItemHeight + ToCurrentPPI(4)) + OutputTabSet.Height;
   MaxHeight := BodyPanel.ClientHeight - ToCurrentPPI(48) - SplitPanel.Height;
   if H > MaxHeight then H := MaxHeight;
   if H < MinHeight then H := MinHeight;
@@ -3740,9 +3740,9 @@ begin
   SplitPanel.ParentBackground := False;
   SplitPanel.Color := FTheme.Colors[tcSplitterBack];
   if FTheme.Dark then
-    TabSet.Theme := FTheme
+    OutputTabSet.Theme := FTheme
   else
-    TabSet.Theme := nil;
+    OutputTabSet.Theme := nil;
   CompilerOutputList.Font.Color := FTheme.Colors[tcFore];
   CompilerOutputList.Color := FTheme.Colors[tcBack];
   CompilerOutputList.Invalidate;
@@ -3807,8 +3807,8 @@ begin
   SendMessage(DebugOutputList.Handle, LB_SETHORIZONTALEXTENT, 0, 0);
   DebugCallStackList.Clear;
   SendMessage(DebugCallStackList.Handle, LB_SETHORIZONTALEXTENT, 0, 0);
-  if not (TabSet.TabIndex in [tiDebugOutput, tiDebugCallStack]) then
-    TabSet.TabIndex := tiDebugOutput;
+  if not (OutputTabSet.TabIndex in [tiDebugOutput, tiDebugCallStack]) then
+    OutputTabSet.TabIndex := tiDebugOutput;
   SetStatusPanelVisible(True);
 
   FillChar(Info, SizeOf(Info), 0);
@@ -4351,9 +4351,9 @@ begin
   Canvas.TextOut(Rect.Left, Rect.Top, S);
 end;
 
-procedure TCompileForm.TabSetClick(Sender: TObject);
+procedure TCompileForm.OutputTabSetClick(Sender: TObject);
 begin
-  case TabSet.TabIndex of
+  case OutputTabSet.TabIndex of
     tiCompilerOutput:
       begin
         CompilerOutputList.BringToFront;

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -1693,7 +1693,7 @@ var
   Memo: TCompScintEdit;
 begin
   for Memo in FMemos do
-    if Memo.Used then
+    if Memo.Used and Memo.Modified then
       SaveFile(Memo, False);
 end;
 
@@ -2670,7 +2670,7 @@ procedure TCompileForm.MemoUpdateUI(Sender: TObject);
   end;
 
 begin
-  if (Sender = FErrorMemo) and (FErrorMemo.ErrorLine < 0) or (FErrorMemo.CaretPosition <> FErrorMemo.ErrorCaretPosition) then
+  if (Sender = FErrorMemo) and ((FErrorMemo.ErrorLine < 0) or (FErrorMemo.CaretPosition <> FErrorMemo.ErrorCaretPosition)) then
     HideError;
   UpdateCaretPosPanel;
   UpdatePendingSquiggly;

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -195,6 +195,7 @@ type
     ToolBarPanel: TPanel;
     HMailingList: TMenuItem;
     MemosTabSet: TNewTabSet;
+    FSaveAll: TMenuItem;
     procedure FormCloseQuery(Sender: TObject; var CanClose: Boolean);
     procedure FExitClick(Sender: TObject);
     procedure FOpenMainFileClick(Sender: TObject);
@@ -281,6 +282,7 @@ type
     procedure HMailingListClick(Sender: TObject);
     procedure TInsertMsgBoxClick(Sender: TObject);
     procedure MemosTabSetClick(Sender: TObject);
+    procedure FSaveAllClick(Sender: TObject);
   private
     { Private declarations }
     FMemos: TList<TCompScintEdit>; { FMemos[0] is always the main memo }
@@ -1592,6 +1594,7 @@ begin
   FSaveMainFileAs.Enabled := FActiveMemo = FMainMemo;
   FSaveEncodingAuto.Checked := not FActiveMemo.SaveInUTF8Encoding;
   FSaveEncodingUTF8.Checked := FActiveMemo.SaveInUTF8Encoding;
+  FSaveAll.Visible := FOptions.OpenIncludedFiles;
   ReadMRUMainFilesList;
   FMRUMainFilesSep.Visible := FMRUMainFilesList.Count <> 0;
   for I := 0 to High(FMRUMainFilesMenuItems) do
@@ -1647,6 +1650,15 @@ end;
 procedure TCompileForm.FSaveEncodingItemClick(Sender: TObject);
 begin
   FActiveMemo.SaveInUTF8Encoding := (Sender = FSaveEncodingUTF8);
+end;
+
+procedure TCompileForm.FSaveAllClick(Sender: TObject);
+var
+  Memo: TCompScintEdit;
+begin
+  for Memo in FMemos do
+    if Memo.Visible then
+      SaveFile(Memo, False);
 end;
 
 procedure TCompileForm.FMRUClick(Sender: TObject);

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -2946,11 +2946,8 @@ end;
 procedure TCompileForm.MainMemoDropFiles(Sender: TObject; X, Y: Integer;
   AFiles: TStrings);
 begin
-  if (AFiles.Count > 0) and ConfirmCloseFile(True, True) then begin
-    OpenFile(FActiveMemo, AFiles[0], True);
-    if FActiveMemo <> FMainMemo then
-      FActiveMemo.ForceModifiedState;
-  end;
+  if (AFiles.Count > 0) and ConfirmCloseFile(True, True) then
+    OpenFile(FMainMemo, AFiles[0], True);
 end;
 
 procedure TCompileForm.StatusBarResize(Sender: TObject);

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -23,7 +23,7 @@ interface
 
 uses
   Windows, Messages, SysUtils, Classes, Contnrs, Graphics, Controls, Forms, Dialogs,
-  UIStateForm, StdCtrls, ExtCtrls, Menus, Buttons, ComCtrls, CommCtrl,
+  Generics.Collections, UIStateForm, StdCtrls, ExtCtrls, Menus, Buttons, ComCtrls, CommCtrl,
   ScintInt, ScintEdit, ScintStylerInnoSetup, NewTabSet, ModernColors,
   DebugStruct, CompInt, UxTheme, ImageList, ImgList, ToolWin,
   VirtualImageList, BaseImageCollection, ImageCollection;
@@ -273,7 +273,7 @@ type
     procedure IncludedFilesTabSetClick(Sender: TObject);
   private
     { Private declarations }
-    FMemos: TList;
+    FMemos: TList<TISScintEdit>;
     FMainMemo: TISScintEdit;
     FActiveMemo: TISScintEdit;
     FMemosStyler: TInnoSetupStyler;
@@ -986,7 +986,7 @@ begin
   FMemosStyler := TInnoSetupStyler.Create(Self);
   FMemosStyler.IsppInstalled := IsppInstalled;
   FTheme := TTheme.Create;
-  FMemos := TList.Create;
+  FMemos := TList<TISScintEdit>.Create;
   for I := 0 to MaxMemos-1 do
     FMemos.Add(CreateMemo(PopupMenu));
   FMainMemo := FMemos[0];
@@ -2510,7 +2510,7 @@ var
   I: Integer;
 begin
   for I := 0 to IncludedFilesTabSet.Tabs.Count-1 do begin
-    Memo := TISScintEdit(FMemos[I]);
+    Memo := FMemos[I];
     Memo.Visible := (I = IncludedFilesTabSet.TabIndex);
     if Memo.Visible then begin
       FActiveMemo := Memo;
@@ -2945,7 +2945,7 @@ begin
       end;
       { Hide any remaining memos }
       for I := FIncludedFiles.Count to FMemos.Count-1 do
-        TScintEdit(FMemos[I]).Visible := False;
+        FMemos[I].Visible := False;
       IncludedFilesTabSet.Tabs := NewTabs;
     finally
       NewTabs.Free;
@@ -2953,7 +2953,7 @@ begin
     IncludedFilesTabSet.Visible := True;
   end else begin
     for I := 1 to FMemos.Count-1 do
-      TScintEdit(FMemos[I]).Visible := False;
+      FMemos[I].Visible := False;
     for I := 1 to FIncludedFiles.Count-1 do begin
       IncludedFile := TIncludedFile(FIncludedFiles[I]);
       IncludedFile.Memo := nil;

--- a/Projects/CompForm.pas
+++ b/Projects/CompForm.pas
@@ -1250,7 +1250,7 @@ type
 {ok}function CompilerCallbackProc(Code: Integer; var Data: TCompilerCallbackData;
   AppData: Longint): Integer; stdcall;
 
-  procedure ParseIncludedFilenames(P: PChar; const IncludedFiles: TIncludedFiles);
+  procedure DecodeIncludedFilenames(P: PChar; const IncludedFiles: TIncludedFiles);
   var
     IncludedFile: TIncludedFile;
   begin
@@ -1313,7 +1313,7 @@ begin
             Result := iscrRequestAbort;
         end;
       iscbNotifyIncludedFiles:
-        ParseIncludedFilenames(Data.IncludedFilenames, IncludedFiles); { Also stores last write time }
+        DecodeIncludedFilenames(Data.IncludedFilenames, IncludedFiles); { Also stores last write time }
       iscbNotifySuccess:
         begin
           OutputExe := Data.OutputExeFilename;

--- a/Projects/CompFunc.pas
+++ b/Projects/CompFunc.pas
@@ -143,7 +143,7 @@ end;
 
 function IsISPPBuiltins(const Filename: String): Boolean;
 begin
-  Result := SameText(PathExtractName(Filename), 'ISPPBuiltins.iss');
+  Result := PathCompare(PathExtractName(Filename), 'ISPPBuiltins.iss') = 0;
 end;
 
 function ISCryptInstalled: Boolean;

--- a/Projects/CompFunc.pas
+++ b/Projects/CompFunc.pas
@@ -1,0 +1,425 @@
+unit CompFunc;
+
+{
+  Inno Setup
+  Copyright (C) 1997-2020 Jordan Russell
+  Portions by Martijn Laan
+  For conditions of distribution and use, see LICENSE.TXT.
+
+  Common Compiler IDE functions
+}
+
+{$I VERSION.INC}
+
+{$IFDEF IS_D6}
+{$WARN SYMBOL_PLATFORM OFF}
+{$ENDIF}
+
+interface
+
+uses
+  Windows,
+  Classes, Forms, Dialogs, Menus, StdCtrls,
+  ScintEdit, ModernColors;
+
+const
+  MRUListMaxCount = 10;
+
+type
+  TMRUItemCompareProc = function(const S1, S2: String): Integer;
+  TAddLinesPrefix = (alpNone, alpTimestamp, alpCountdown);
+
+procedure InitFormFont(Form: TForm);
+function GetDisplayFilename(const Filename: String): String;
+function GetLastWriteTimeOfFile(const Filename: String;
+  LastWriteTime: PFileTime): Boolean;
+procedure AddFileToRecentDocs(const Filename: String);
+function GenerateGuid: String;
+function ISPPInstalled: Boolean;
+function IsISPPBuiltins(const Filename: String): Boolean;
+function ISCryptInstalled: Boolean;
+function GetDefaultThemeType: TThemeType;
+procedure OpenDonateSite;
+procedure OpenMailingListSite;
+procedure ReadMRUList(const MRUList: TStringList; const Section, Ident: String);
+procedure ModifyMRUList(const MRUList: TStringList; const Section, Ident: String;
+  const AItem: String; const AddNewItem: Boolean; CompareProc: TMRUItemCompareProc);
+procedure SetFakeShortCutText(const MenuItem: TMenuItem; const S: String);
+procedure SetFakeShortCut(const MenuItem: TMenuItem; const Key: Word;
+  const Shift: TShiftState);
+procedure SaveTextToFile(const Filename: String;
+  const S: String; const ForceUTF8Encoding: Boolean);
+procedure AddLines(const ListBox: TListBox; const S: String; const AObject: TObject; const LineBreaks: Boolean; const Prefix: TAddLinesPrefix; const PrefixParam: Cardinal);
+procedure SetLowPriority(ALowPriority: Boolean; var SavePriorityClass: DWORD);
+function GetHelpFile: String;
+function FindOptionsToSearchOptions(const FindOptions: TFindOptions): TScintFindOptions;
+procedure StartAddRemovePrograms;
+
+implementation
+
+uses
+  ActiveX, ShlObj, ShellApi, CommDlg, SysUtils,
+  Messages,
+  CmnFunc2, PathFunc, FileClass,
+  CompMsgs, CompTypes;
+
+procedure InitFormFont(Form: TForm);
+var
+  FontName: String;
+  Metrics: TNonClientMetrics;
+begin
+  begin
+    Metrics.cbSize := SizeOf(Metrics);
+    if SystemParametersInfo(SPI_GETNONCLIENTMETRICS, SizeOf(Metrics),
+       @Metrics, 0) then
+      FontName := Metrics.lfMessageFont.lfFaceName;
+    { Only allow fonts that we know will fit the text correctly }
+    if not SameText(FontName, 'Microsoft Sans Serif') and
+       not SameText(FontName, 'Segoe UI') then
+      FontName := 'Tahoma';
+  end;
+  Form.Font.Name := FontName;
+  Form.Font.Size := 8;
+end;
+
+function GetDisplayFilename(const Filename: String): String;
+var
+  Buf: array[0..MAX_PATH-1] of Char;
+begin
+  if GetFileTitle(PChar(Filename), Buf, SizeOf(Buf)) = 0 then
+    Result := Buf
+  else
+    Result := Filename;
+end;
+
+function GetLastWriteTimeOfFile(const Filename: String;
+  LastWriteTime: PFileTime): Boolean;
+var
+  H: THandle;
+begin
+  H := CreateFile(PChar(Filename), 0, FILE_SHARE_READ or FILE_SHARE_WRITE,
+    nil, OPEN_EXISTING, 0, 0);
+  if H <> INVALID_HANDLE_VALUE then begin
+    Result := GetFileTime(H, nil, nil, LastWriteTime);
+    CloseHandle(H);
+  end
+  else
+    Result := False;
+end;
+
+procedure AddFileToRecentDocs(const Filename: String);
+{ Notifies the shell that a document has been opened. On Windows 7, this will
+  add the file to the Recent section of the app's Jump List.
+  It is only necessary to call this function when the shell is unaware that
+  a file is being opened. Files opened through Explorer or common dialogs get
+  added to the Jump List automatically. }
+begin
+  SHAddToRecentDocs(SHARD_PATHW, PChar(Filename));
+end;
+
+function GenerateGuid: String;
+var
+  Guid: TGUID;
+  P: PWideChar;
+begin
+  if CoCreateGuid(Guid) <> S_OK then
+    raise Exception.Create('CoCreateGuid failed');
+  if StringFromCLSID(Guid, P) <> S_OK then
+    raise Exception.Create('StringFromCLSID failed');
+  try
+    Result := P;
+  finally
+    CoTaskMemFree(P);
+  end;
+end;
+
+function ISPPInstalled: Boolean;
+begin
+  Result := NewFileExists(PathExtractPath(NewParamStr(0)) + 'ISPP.dll');
+end;
+
+function IsISPPBuiltins(const Filename: String): Boolean;
+begin
+  Result := SameText(PathExtractName(Filename), 'ISPPBuiltins.iss');
+end;
+
+function ISCryptInstalled: Boolean;
+begin
+  Result := NewFileExists(PathExtractPath(NewParamStr(0)) + 'iscrypt.dll');
+end;
+
+function GetDefaultThemeType: TThemeType;
+var
+  K: HKEY;
+  Size, AppsUseLightTheme: DWORD;
+begin
+  Result := ttModernLight;
+  if (Win32MajorVersion >= 10) and (RegOpenKeyExView(rvDefault, HKEY_CURRENT_USER, 'SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize', 0, KEY_QUERY_VALUE, K) = ERROR_SUCCESS) then begin
+    Size := SizeOf(AppsUseLightTheme);
+    if (RegQueryValueEx(K, 'AppsUseLightTheme', nil, nil, @AppsUseLightTheme, @Size) = ERROR_SUCCESS) and (AppsUseLightTheme = 0) then
+      Result := ttModernDark;
+    RegCloseKey(K);
+  end;
+end;
+
+procedure OpenDonateSite;
+begin
+  ShellExecute(Application.Handle, 'open', 'https://jrsoftware.org/isdonate.php', nil,
+    nil, SW_SHOW);
+end;
+
+procedure OpenMailingListSite;
+begin
+  ShellExecute(Application.Handle, 'open', 'https://jrsoftware.org/ismail.php', nil,
+    nil, SW_SHOW);
+end;
+
+procedure ReadMRUList(const MRUList: TStringList; const Section, Ident: String);
+{ Loads a list of MRU items from the registry }
+var
+  Ini: TConfigIniFile;
+  I: Integer;
+  S: String;
+begin
+  Ini := TConfigIniFile.Create;
+  try
+    MRUList.Clear;
+    for I := 0 to MRUListMaxCount-1 do begin
+      S := Ini.ReadString(Section, Ident + IntToStr(I), '');
+      if S <> '' then MRUList.Add(S);
+    end;
+  finally
+    Ini.Free;
+  end;
+end;
+
+procedure ModifyMRUList(const MRUList: TStringList; const Section, Ident: String;
+  const AItem: String; const AddNewItem: Boolean; CompareProc: TMRUItemCompareProc);
+var
+  I: Integer;
+  Ini: TConfigIniFile;
+  S: String;
+begin
+  I := 0;
+  while I < MRUList.Count do begin
+    if CompareProc(MRUList[I], AItem) = 0 then
+      MRUList.Delete(I)
+    else
+      Inc(I);
+  end;
+  if AddNewItem then
+    MRUList.Insert(0, AItem);
+  while MRUList.Count > MRUListMaxCount do
+    MRUList.Delete(MRUList.Count-1);
+
+  { Save new MRU items }
+  Ini := TConfigIniFile.Create;
+  try
+    { MRU list }
+    for I := 0 to MRUListMaxCount-1 do begin
+      if I < MRUList.Count then
+        S := MRUList[I]
+      else
+        S := '';
+      Ini.WriteString(Section, Ident + IntToStr(I), S);
+    end;
+  finally
+    Ini.Free;
+  end;
+end;
+
+procedure SetFakeShortCutText(const MenuItem: TMenuItem; const S: String);
+begin
+  MenuItem.Caption := MenuItem.Caption + #9 + S;
+end;
+
+procedure SetFakeShortCut(const MenuItem: TMenuItem; const Key: Word;
+  const Shift: TShiftState);
+begin
+  SetFakeShortCutText(MenuItem, ShortCutToText(ShortCut(Key, Shift)));
+end;
+
+procedure SaveTextToFile(const Filename: String;
+  const S: String; const ForceUTF8Encoding: Boolean);
+var
+  AnsiMode: Boolean;
+  AnsiStr: AnsiString;
+  F: TTextFileWriter;
+begin
+  AnsiMode := False;
+  if not ForceUTF8Encoding then begin
+    AnsiStr := AnsiString(S);
+    if S = String(AnsiStr) then
+      AnsiMode := True;
+  end;
+
+  F := TTextFileWriter.Create(Filename, fdCreateAlways, faWrite, fsNone);
+  try
+    if AnsiMode then
+      F.WriteAnsi(AnsiStr)
+    else
+      F.Write(S);
+  finally
+    F.Free;
+  end;
+end;
+
+procedure AddLines(const ListBox: TListBox; const S: String; const AObject: TObject; const LineBreaks: Boolean; const Prefix: TAddLinesPrefix; const PrefixParam: Cardinal);
+var
+  ST: TSystemTime;
+  LineNumber: Cardinal;
+
+  procedure AddLine(S: String);
+  var
+    TimestampPrefixTab: Boolean;
+    DC: HDC;
+    Size: TSize;
+  begin
+    TimestampPrefixTab := False;
+    case Prefix of
+      alpTimestamp:
+        begin
+          if LineNumber = 0 then begin
+            { Don't forget about ListBox's DrawItem if you change the format of the following timestamp. }
+            Insert(Format('[%.2u%s%.2u%s%.2u%s%.3u]   ', [ST.wHour, {$IFDEF IS_DXE}FormatSettings.{$ENDIF}TimeSeparator,
+              ST.wMinute, {$IFDEF IS_DXE}FormatSettings.{$ENDIF}TimeSeparator, ST.wSecond, {$IFDEF IS_DXE}FormatSettings.{$ENDIF}DecimalSeparator,
+              ST.wMilliseconds]), S, 1);
+          end else begin
+            Insert(#9, S, 1); { Not actually painted - just for Ctrl+C }
+            TimestampPrefixTab := True;
+          end;
+        end;
+      alpCountdown:
+        begin
+          Insert(Format('[%.2d]   ', [PrefixParam-LineNumber]), S, 1);
+        end;
+    end;
+    try
+      ListBox.TopIndex := ListBox.Items.AddObject(S, AObject);
+    except
+      on EOutOfResources do begin
+        ListBox.Clear;
+        SendMessage(ListBox.Handle, LB_SETHORIZONTALEXTENT, 0, 0);
+        ListBox.Items.Add(SCompilerStatusReset);
+        ListBox.TopIndex := ListBox.Items.Add(S);
+      end;
+    end;
+    DC := GetDC(0);
+    try
+      SelectObject(DC, ListBox.Font.Handle);
+      if TimestampPrefixTab then
+        GetTextExtentPoint(DC, PChar(S)+1, Length(S)-1, Size)
+      else
+        GetTextExtentPoint(DC, PChar(S), Length(S), Size);
+    finally
+      ReleaseDC(0, DC);
+    end;
+    Inc(Size.cx, 5);
+    if TimestampPrefixTab then
+      Inc(Size.cx, PrefixParam);
+    if Size.cx > SendMessage(ListBox.Handle, LB_GETHORIZONTALEXTENT, 0, 0) then
+      SendMessage(ListBox.Handle, LB_SETHORIZONTALEXTENT, Size.cx, 0);
+    Inc(LineNumber);
+  end;
+
+var
+  LineStart, I: Integer;
+  LastWasCR: Boolean;
+begin
+  GetLocalTime(ST);
+  if LineBreaks then begin
+    LineNumber := 0;
+    LineStart := 1;
+    LastWasCR := False;
+    { Call AddLine for each line. CR, LF, and CRLF line breaks are supported. }
+    for I := 1 to Length(S) do begin
+      if S[I] = #13 then begin
+        AddLine(Copy(S, LineStart, I - LineStart));
+        LineStart := I + 1;
+        LastWasCR := True;
+      end
+      else begin
+        if S[I] = #10 then begin
+          if not LastWasCR then
+            AddLine(Copy(S, LineStart, I - LineStart));
+          LineStart := I + 1;
+        end;
+        LastWasCR := False;
+      end;
+    end;
+    AddLine(Copy(S, LineStart, Maxint));
+  end else
+    AddLine(S);
+end;
+
+procedure SetLowPriority(ALowPriority: Boolean; var SavePriorityClass: DWORD);
+begin
+  if ALowPriority then begin
+    { Save current priority and change to 'low' }
+    if SavePriorityClass = 0 then
+      SavePriorityClass := GetPriorityClass(GetCurrentProcess);
+    SetPriorityClass(GetCurrentProcess, IDLE_PRIORITY_CLASS);
+  end
+  else begin
+    { Restore original priority }
+    if SavePriorityClass <> 0 then begin
+      SetPriorityClass(GetCurrentProcess, SavePriorityClass);
+      SavePriorityClass := 0;
+    end;
+  end;
+end;
+
+function GetHelpFile: String;
+begin
+  Result := PathExtractPath(NewParamStr(0)) + 'isetup.chm';
+end;
+
+function FindOptionsToSearchOptions(const FindOptions: TFindOptions): TScintFindOptions;
+begin
+  Result := [];
+  if frMatchCase in FindOptions then
+    Include(Result, sfoMatchCase);
+  if frWholeWord in FindOptions then
+    Include(Result, sfoWholeWord);
+end;
+
+procedure StartAddRemovePrograms;
+var
+  Dir: String;
+  Wow64DisableWow64FsRedirectionFunc: function(var OldValue: Pointer): BOOL; stdcall;
+  Wow64RevertWow64FsRedirectionFunc: function(OldValue: Pointer): BOOL; stdcall;
+  RedirDisabled: Boolean;
+  RedirOldValue: Pointer;
+  StartupInfo: TStartupInfo;
+  ProcessInfo: TProcessInformation;
+begin
+  if Win32Platform = VER_PLATFORM_WIN32_NT then
+    Dir := GetSystemDir
+  else
+    Dir := GetWinDir;
+
+  FillChar(StartupInfo, SizeOf(StartupInfo), 0);
+  StartupInfo.cb := SizeOf(StartupInfo);
+  { Have to disable file system redirection because the 32-bit version of
+    appwiz.cpl is buggy on XP x64 RC2 -- it doesn't show any Change/Remove
+    buttons on 64-bit MSI entries, and it doesn't list non-MSI 64-bit apps
+    at all. }
+  Wow64DisableWow64FsRedirectionFunc := GetProcAddress(GetModuleHandle(kernel32),
+    'Wow64DisableWow64FsRedirection');
+  Wow64RevertWow64FsRedirectionFunc := GetProcAddress(GetModuleHandle(kernel32),
+    'Wow64RevertWow64FsRedirection');
+  RedirDisabled := Assigned(Wow64DisableWow64FsRedirectionFunc) and
+    Assigned(Wow64RevertWow64FsRedirectionFunc) and
+    Wow64DisableWow64FsRedirectionFunc(RedirOldValue);
+  try
+    Win32Check(CreateProcess(nil, PChar('"' + AddBackslash(Dir) + 'control.exe" appwiz.cpl'),
+       nil, nil, False, 0, nil, PChar(Dir), StartupInfo, ProcessInfo));
+  finally
+    if RedirDisabled then
+      Wow64RevertWow64FsRedirectionFunc(RedirOldValue);
+  end;
+  CloseHandle(ProcessInfo.hProcess);
+  CloseHandle(ProcessInfo.hThread);
+end;
+
+end.

--- a/Projects/CompInputQueryCombo.pas
+++ b/Projects/CompInputQueryCombo.pas
@@ -37,7 +37,7 @@ function InputQueryCombo(const ACaption, APrompt: String; var AValue: String; co
 implementation
 
 uses
-  Windows, Messages, CompForm, Forms;
+  Windows, Messages, CompFunc, Forms;
 
 {$R *.DFM}
 

--- a/Projects/CompInt.pas
+++ b/Projects/CompInt.pas
@@ -89,9 +89,10 @@ type
                                 was aborted by the application. }
         ErrorFilename: PChar; { [in] Filename in which the error occurred. This
                                 is NULL if the file is the main script. }
-        ErrorLine: Integer);  { [in] The line number the error occurred on.
+        ErrorLine: Integer;   { [in] The line number the error occurred on.
                                 Zero if the error doesn't apply to any
                                 particular line. }
+        IncludedFilenamesSoFar: PChar); { [in] See IncludedFilenames above (new in 6.1.0) }
   end;
 
   TCompilerCallbackProc = function(Code: Integer;

--- a/Projects/CompInt.pas
+++ b/Projects/CompInt.pas
@@ -32,10 +32,10 @@ const
                              TCompilerCallbackData; the compiler will ignore
                              them.) }
 
-  { Return values for ISDllCompileScript and ISDllScanScript }
+  { Return values for ISDllCompileScript }
   isceNoError = 0;         { Successful }
   isceInvalidParam = 1;    { Bad parameters passed to function }
-  isceFailure = 2;         { There was an error or compiling/scanning was aborted
+  isceCompileFailure = 2;  { There was an error compiling or it was aborted
                              by the application }
 
 type
@@ -116,9 +116,9 @@ type
                             to read the script and for status notification. }
     AppData: Longint;     { [in] Application-defined. AppData is passed to the
                             callback function. }
-    Options: PChar;       { [in] Additional options for ISDllCompileScript.
-                            Each option is a null-terminated string, and the final
-                            option is followed by an additional null character.
+    Options: PChar;       { [in] Additional options. Each option is a
+                            null-terminated string, and the final option is
+                            followed by an additional null character.
                             If you do not wish to specify any options, set this
                             field to NULL or to point to a single null
                             character.
@@ -167,13 +167,6 @@ const
   isce* constants. }
 function ISDllCompileScript(const Params: TCompileScriptParamsEx): Integer;
   stdcall; external ISCmplrDLL name 'ISDllCompileScriptW';
-
-{ The ISDllScanScript function begins scanning of a script. See the above
-  description of the TCompileScriptParams record. Return value is one of the
-  isce* constants. Only passes iscbReadScript and iscbNotifyIncludedFiles in
-  Code parameter of callback function. }
-function ISDllScanScript(const Params: TCompileScriptParamsEx): Integer;
-  stdcall; external ISCmplrDLL name 'ISDllScanScriptW';
 
 { The ISDllGetVersion returns a pointer to a TCompilerVersionInfo record which
   contains information about the compiler version. }

--- a/Projects/CompInt.pas
+++ b/Projects/CompInt.pas
@@ -35,7 +35,7 @@ const
   { Return values for ISDllCompileScript and ISDllScanScript }
   isceNoError = 0;         { Successful }
   isceInvalidParam = 1;    { Bad parameters passed to function }
-  isceError = 2;           { There was an error or compiling/scanning was aborted
+  isceFailure = 2;         { There was an error or compiling/scanning was aborted
                              by the application }
 
 type

--- a/Projects/CompInt.pas
+++ b/Projects/CompInt.pas
@@ -22,6 +22,7 @@ const
   iscbNotifySuccess = 4;   { Sent when compilation succeeds }
   iscbNotifyError = 5;     { Sent when compilation fails or is aborted by the
                              application }
+  iscbNotifyIncludedFiles = 6; { Sent to notify the application of included files }
 
   { Return values for callback function }
   iscrSuccess = 0;         { Return this for compiler to continue }
@@ -73,26 +74,27 @@ type
         BytesCompressedPerSecond: Cardinal); { [in] Average bytes compressed
                                                per second (new in 5.1.13) }
 
+      iscbNotifyIncludedFiles: (
+        IncludedFilenames: PChar); { [in] Names of #included files. Each name is
+                                          a null-terminated string, and the final
+                                          name is followed by an additional null
+                                          character (new in 6.1.0) }
+
       iscbNotifySuccess: (
         OutputExeFilename: PChar;  { [in] The name of the resulting setup.exe,
                                           or empty if output was disabled
                                           (latter new in 5.5.5) }
         DebugInfo: Pointer;        { [in] Debug info (new in 3.0.0.1) }
-        DebugInfoSize: Cardinal;   { [in] Size of debug info (new in 3.0.0.1) }
-        IncludedFilenames: PChar); { [in] Names of #included files. Each name is
-                                          a null-terminated string, and the final
-                                          name is followed by an additional null
-                                          character (new in 6.1.0) }
+        DebugInfoSize: Cardinal);  { [in] Size of debug info (new in 3.0.0.1) }
 
       iscbNotifyError: (
         ErrorMsg: PChar;      { [in] The error message, or NULL if compilation
                                 was aborted by the application. }
         ErrorFilename: PChar; { [in] Filename in which the error occurred. This
                                 is NULL if the file is the main script. }
-        ErrorLine: Integer;   { [in] The line number the error occurred on.
+        ErrorLine: Integer);  { [in] The line number the error occurred on.
                                 Zero if the error doesn't apply to any
                                 particular line. }
-        IncludedFilenamesSoFar: PChar); { [in] See IncludedFilenames above (new in 6.1.0) }
   end;
 
   TCompilerCallbackProc = function(Code: Integer;

--- a/Projects/CompMessageBoxDesigner.pas
+++ b/Projects/CompMessageBoxDesigner.pas
@@ -110,7 +110,7 @@ type
 implementation
 
 uses
-  CmnFunc, CmnFunc2, CompForm, TaskDialog, Msgs;
+  CmnFunc, CmnFunc2, CompFunc, TaskDialog, Msgs;
 
 {$R *.DFM}
 

--- a/Projects/CompOptions.dfm
+++ b/Projects/CompOptions.dfm
@@ -100,6 +100,14 @@ object OptionsForm: TOptionsForm
       Caption = 'Colori&ze "Compiler Output" view'
       TabOrder = 8
     end
+    object OpenIncludedFilesCheck: TCheckBox
+      Left = 8
+      Top = 196
+      Width = 265
+      Height = 17
+      Caption = 'Open #include-ed files after compilation'
+      TabOrder = 9
+    end
   end
   object GroupBox2: TGroupBox
     Left = 8

--- a/Projects/CompOptions.pas
+++ b/Projects/CompOptions.pas
@@ -63,7 +63,7 @@ type
 implementation
 
 uses
-  CmnFunc, CmnFunc2, CompForm, CompFileAssoc;
+  CmnFunc, CmnFunc2, CompFunc, CompFileAssoc;
 
 {$R *.DFM}
 

--- a/Projects/CompOptions.pas
+++ b/Projects/CompOptions.pas
@@ -49,6 +49,7 @@ type
     ColorizeCompilerOutputCheck: TCheckBox;
     Label3: TNewStaticText;
     ThemeComboBox: TComboBox;
+    OpenIncludedFilesCheck: TCheckBox;
     procedure AssocButtonClick(Sender: TObject);
     procedure ChangeFontButtonClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);

--- a/Projects/CompScintEdit.pas
+++ b/Projects/CompScintEdit.pas
@@ -1,0 +1,182 @@
+unit CompScintEdit;
+
+{
+  Inno Setup
+  Copyright (C) 1997-2020 Jordan Russell
+  Portions by Martijn Laan
+  For conditions of distribution and use, see LICENSE.TXT.
+
+  Compiler IDE's TScintEdit
+}
+
+interface
+
+uses
+  Windows, Graphics, ScintEdit, ModernColors;
+
+const
+  { Memo marker numbers }
+  mmIconHasEntry = 0;        { grey dot }
+  mmIconEntryProcessed = 1;  { green dot }
+  mmIconBreakpoint = 2;      { stop sign }
+  mmIconBreakpointGood = 3;  { stop sign + check }
+  mmIconBreakpointBad = 4;   { stop sign + X }
+  mmLineError = 10;          { red line highlight }
+  mmLineBreakpoint = 11;     { red line highlight }
+  mmLineBreakpointBad = 12;  { ugly olive line highlight }
+  mmLineStep = 13;           { blue line highlight }
+
+  { Memo indicator numbers (also in ScintStylerInnoSetup) }
+  inSquiggly = 0;
+  inPendingSquiggly = 1;
+
+type
+  TCompScintEdit = class(TScintEdit)
+  private
+    FFilename: String;
+    FFileLastWriteTime: TFileTime;
+    FSaveInUTF8Encoding: Boolean;
+    FTheme: TTheme;
+  protected
+    procedure CreateWnd; override;
+  public
+    property Filename: String read FFileName write FFileName;
+    property FileLastWriteTime: TFileTime read FFileLastWriteTime write FFileLastWriteTime;
+    property SaveInUTF8Encoding: Boolean read FSaveInUTF8Encoding write FSaveInUTF8Encoding;
+    property Theme: TTheme read FTheme write FTheme;
+    procedure UpdateThemeColors;
+  end;
+
+implementation
+
+uses
+  ScintInt;
+
+procedure TCompScintEdit.CreateWnd;
+const
+  PixmapHasEntry: array[0..8] of PAnsiChar = (
+    '5 5 2 1',
+    'o c #808080',
+    '. c #c0c0c0',
+    'ooooo',
+    'o...o',
+    'o...o',
+    'o...o',
+    'ooooo',
+    nil);
+  PixmapEntryProcessed: array[0..8] of PAnsiChar = (
+    '5 5 2 1',
+    'o c #008000',
+    '. c #00ff00',
+    'ooooo',
+    'o...o',
+    'o...o',
+    'o...o',
+    'ooooo',
+    nil);
+  PixmapBreakpoint: array[0..14] of PAnsiChar = (
+    '9 10 3 1',
+    '= c none',
+    'o c #000000',
+    '. c #ff0000',
+    '=========',
+    '==ooooo==',
+    '=o.....o=',
+    'o.......o',
+    'o.......o',
+    'o.......o',
+    'o.......o',
+    'o.......o',
+    '=o.....o=',
+    '==ooooo==',
+    nil);
+  PixmapBreakpointGood: array[0..15] of PAnsiChar = (
+    '9 10 4 1',
+    '= c none',
+    'o c #000000',
+    '. c #ff0000',
+    '* c #00ff00',
+    '======oo=',
+    '==oooo**o',
+    '=o....*o=',
+    'o....**.o',
+    'o....*..o',
+    'o...**..o',
+    'o**.*...o',
+    'o.***...o',
+    '=o.*...o=',
+    '==ooooo==',
+    nil);
+  PixmapBreakpointBad: array[0..15] of PAnsiChar = (
+    '9 10 4 1',
+    '= c none',
+    'o c #000000',
+    '. c #ff0000',
+    '* c #ffff00',
+    '=========',
+    '==ooooo==',
+    '=o.....o=',
+    'o.*...*.o',
+    'o.**.**.o',
+    'o..***..o',
+    'o.**.**.o',
+    'o.*...*.o',
+    '=o.....o=',
+    '==ooooo==',
+    nil);
+const
+  SC_MARK_BACKFORE = 3030;  { new marker type added in Inno Setup's Scintilla build }
+begin
+  inherited;
+
+  Call(SCI_SETCARETWIDTH, 2, 0);
+  Call(SCI_AUTOCSETAUTOHIDE, 0, 0);
+  Call(SCI_AUTOCSETCANCELATSTART, 0, 0);
+  Call(SCI_AUTOCSETDROPRESTOFWORD, 1, 0);
+  Call(SCI_AUTOCSETIGNORECASE, 1, 0);
+  Call(SCI_AUTOCSETMAXHEIGHT, 7, 0);
+
+  Call(SCI_ASSIGNCMDKEY, Ord('Z') or ((SCMOD_SHIFT or SCMOD_CTRL) shl 16), SCI_REDO);
+
+  Call(SCI_SETSCROLLWIDTH, 1024 * CallStr(SCI_TEXTWIDTH, 0, 'X'), 0);
+
+  Call(SCI_INDICSETSTYLE, inSquiggly, INDIC_SQUIGGLE);
+  Call(SCI_INDICSETFORE, inSquiggly, clRed); { May be overwritten by UpdateThemeColors }
+  Call(SCI_INDICSETSTYLE, inPendingSquiggly, INDIC_HIDDEN);
+
+  Call(SCI_SETMARGINTYPEN, 1, SC_MARGIN_SYMBOL);
+  Call(SCI_SETMARGINWIDTHN, 1, 21);
+  Call(SCI_SETMARGINSENSITIVEN, 1, 1);
+  Call(SCI_SETMARGINCURSORN, 1, SC_CURSORARROW);
+  Call(SCI_SETMARGINLEFT, 0, 2);
+
+  Call(SCI_MARKERDEFINEPIXMAP, mmIconHasEntry, LPARAM(@PixmapHasEntry));
+  Call(SCI_MARKERDEFINEPIXMAP, mmIconEntryProcessed, LPARAM(@PixmapEntryProcessed));
+  Call(SCI_MARKERDEFINEPIXMAP, mmIconBreakpoint, LPARAM(@PixmapBreakpoint));
+  Call(SCI_MARKERDEFINEPIXMAP, mmIconBreakpointGood, LPARAM(@PixmapBreakpointGood));
+  Call(SCI_MARKERDEFINEPIXMAP, mmIconBreakpointBad, LPARAM(@PixmapBreakpointBad));
+  Call(SCI_MARKERDEFINE, mmLineError, SC_MARK_BACKFORE);
+  Call(SCI_MARKERSETFORE, mmLineError, clWhite);
+  Call(SCI_MARKERSETBACK, mmLineError, clMaroon);
+  Call(SCI_MARKERDEFINE, mmLineBreakpoint, SC_MARK_BACKFORE);
+  Call(SCI_MARKERSETFORE, mmLineBreakpoint, clWhite);
+  Call(SCI_MARKERSETBACK, mmLineBreakpoint, clRed);
+  Call(SCI_MARKERDEFINE, mmLineBreakpointBad, SC_MARK_BACKFORE);
+  Call(SCI_MARKERSETFORE, mmLineBreakpointBad, clLime);
+  Call(SCI_MARKERSETBACK, mmLineBreakpointBad, clOlive);
+  Call(SCI_MARKERDEFINE, mmLineStep, SC_MARK_BACKFORE);
+  Call(SCI_MARKERSETFORE, mmLineStep, clWhite);
+  Call(SCI_MARKERSETBACK, mmLineStep, clBlue);
+end;
+
+procedure TCompScintEdit.UpdateThemeColors;
+begin
+  if FTheme <> nil then begin
+    Font.Color := FTheme.Colors[tcFore];
+    Color := FTheme.Colors[tcBack];
+    Call(SCI_SETSELBACK, 1, FTheme.Colors[tcSelBack]);
+    Call(SCI_INDICSETFORE, inSquiggly, FTheme.Colors[tcRed]);
+  end;
+end;
+
+end.

--- a/Projects/CompScintEdit.pas
+++ b/Projects/CompScintEdit.pas
@@ -37,13 +37,16 @@ type
     FFileLastWriteTime: TFileTime;
     FSaveInUTF8Encoding: Boolean;
     FTheme: TTheme;
+    FUsed: Boolean;
   protected
     procedure CreateWnd; override;
   public
+    ErrorLine, ErrorCaretPosition: Integer;
     property Filename: String read FFileName write FFileName;
     property FileLastWriteTime: TFileTime read FFileLastWriteTime write FFileLastWriteTime;
     property SaveInUTF8Encoding: Boolean read FSaveInUTF8Encoding write FSaveInUTF8Encoding;
     property Theme: TTheme read FTheme write FTheme;
+    property Used: Boolean read FUsed write FUsed;
     procedure UpdateThemeColors;
   end;
 

--- a/Projects/CompSignTools.pas
+++ b/Projects/CompSignTools.pas
@@ -46,7 +46,7 @@ type
 implementation
 
 uses
-  Windows, Messages, CmnFunc, CompFunc, Dialogs, SysUtils;
+  Windows, Messages, CompFunc, CmnFunc, Dialogs, SysUtils;
 
 {$R *.DFM}
 

--- a/Projects/CompSignTools.pas
+++ b/Projects/CompSignTools.pas
@@ -46,7 +46,7 @@ type
 implementation
 
 uses
-  Windows, Messages, CompForm, CmnFunc, Dialogs, SysUtils;
+  Windows, Messages, CmnFunc, CompFunc, Dialogs, SysUtils;
 
 {$R *.DFM}
 

--- a/Projects/CompStartup.pas
+++ b/Projects/CompStartup.pas
@@ -59,7 +59,7 @@ type
 implementation
 
 uses
-  CompMsgs, CmnFunc, CmnFunc2, CompForm, ComCtrls;
+  CompMsgs, CmnFunc, CmnFunc2, CompFunc, CompForm, ComCtrls;
 
 {$R *.DFM}
 

--- a/Projects/CompStartup.pas
+++ b/Projects/CompStartup.pas
@@ -44,7 +44,7 @@ type
     procedure MailingListImageClick(Sender: TObject);
   private
     FResult: TStartupFormResult;
-    FResultFileName: TFileName;
+    FResultMainFileName: TFileName;
     procedure SetMRUFilesList(const MRUFilesList: TStringList);
     procedure UpdateImages;
   protected
@@ -53,7 +53,7 @@ type
   public
     property MRUFilesList: TStringList write SetMRUFilesList;
     property Result: TStartupFormResult read FResult;
-    property ResultFileName: TFileName read FResultFileName;
+    property ResultMainFileName: TFileName read FResultMainFileName;
   end;
 
 implementation
@@ -165,7 +165,7 @@ begin
       FResult := srOpenDialogExamples
     else if OpenListBox.ItemIndex > 1 then begin
       FResult := srOpenFile;
-      FResultFileName := OpenListBox.Items[OpenListBox.ItemIndex];
+      FResultMainFileName := OpenListBox.Items[OpenListBox.ItemIndex];
     end else
       FResult := srOpenDialog;
   end;

--- a/Projects/CompStartup.pas
+++ b/Projects/CompStartup.pas
@@ -83,8 +83,8 @@ var
 begin
  { After a DPI change the button's Width and Height isn't yet updated, so calculate it ourselves }
   WH := MulDiv(16, CurrentPPI, 96);
-  NewImage.Picture.Bitmap := GetBitmap(CompileForm.NewButton, WH);
-  OpenImage.Picture.Bitmap := GetBitmap(CompileForm.OpenButton, WH);
+  NewImage.Picture.Bitmap := GetBitmap(CompileForm.NewMainFileButton, WH);
+  OpenImage.Picture.Bitmap := GetBitmap(CompileForm.OpenMainFileButton, WH);
 end;
 
 procedure TStartupForm.FormAfterMonitorDpiChanged(Sender: TObject; OldDPI,

--- a/Projects/CompWizard.pas
+++ b/Projects/CompWizard.pas
@@ -180,8 +180,8 @@ implementation
 
 uses
   SysUtils, ShlObj, ActiveX, UITypes,
-  PathFunc, CmnFunc, CmnFunc2, VerInfo, BrowseFunc,
-  CompMsgs, CompWizardFile, CompForm;
+  PathFunc, CmnFunc, CmnFunc2, CompFunc, VerInfo, BrowseFunc,
+  CompMsgs, CompWizardFile;
 
 type
   TConstant = record

--- a/Projects/CompWizardFile.pas
+++ b/Projects/CompWizardFile.pas
@@ -60,7 +60,7 @@ type
 implementation
 
 uses
-  CompMsgs, CmnFunc, CmnFunc2, CompForm;
+  CompMsgs, CmnFunc, CmnFunc2, CompFunc;
 
 {$R *.DFM}
 

--- a/Projects/Compil32.dpr
+++ b/Projects/Compil32.dpr
@@ -23,6 +23,7 @@ uses
   CompForm in 'CompForm.pas' {CompileForm},
   CmnFunc in 'CmnFunc.pas',
   CmnFunc2 in 'CmnFunc2.pas',
+  CompFunc in 'CompFunc.pas',
   CompMsgs in 'CompMsgs.pas',
   CompInt in 'CompInt.pas',
   CompOptions in 'CompOptions.pas' {OptionsForm},

--- a/Projects/Compil32.dpr
+++ b/Projects/Compil32.dpr
@@ -35,12 +35,13 @@ uses
   DebugStruct in 'DebugStruct.pas',
   BrowseFunc in 'BrowseFunc.pas',
   CompSignTools in 'CompSignTools.pas' {SignToolsForm},
-  CompInputQueryCombo in 'CompInputQueryCombo.pas' {InputQueryCombo},
+  CompInputQueryCombo in 'CompInputQueryCombo.pas',
   ScintInt in '..\Components\ScintInt.pas',
   ScintEdit in '..\Components\ScintEdit.pas',
   ScintStylerInnoSetup in '..\Components\ScintStylerInnoSetup.pas',
   ModernColors in '..\Components\ModernColors.pas',
-  CompMessageBoxDesigner in 'CompMessageBoxDesigner.pas' {MBDForm};
+  CompMessageBoxDesigner in 'CompMessageBoxDesigner.pas' {MBDForm},
+  CompScintEdit in 'CompScintEdit.pas';
 
 {$R *.res}
 {$R Compil32.manifest.res}

--- a/Projects/Compil32.dproj
+++ b/Projects/Compil32.dproj
@@ -77,15 +77,14 @@
 			<DCCReference Include="CompSignTools.pas">
 				<Form>SignToolsForm</Form>
 			</DCCReference>
-			<DCCReference Include="CompInputQueryCombo.pas">
-				<Form>InputQueryCombo</Form>
-			</DCCReference>
+			<DCCReference Include="CompInputQueryCombo.pas"/>
 			<DCCReference Include="CompMessageBoxDesigner.pas">
 				<Form>MBDForm</Form>
 			</DCCReference>
 			<DCCReference Include="..\Components\ScintInt.pas"/>
 			<DCCReference Include="..\Components\ScintEdit.pas"/>
 			<DCCReference Include="..\Components\ScintStylerInnoSetup.pas"/>
+			<DCCReference Include="CompScintEdit.pas"/>
 			<BuildConfiguration Include="Base">
 				<Key>Base</Key>
 			</BuildConfiguration>

--- a/Projects/Compil32.dproj
+++ b/Projects/Compil32.dproj
@@ -55,6 +55,7 @@
 			</DCCReference>
 			<DCCReference Include="CmnFunc.pas"/>
 			<DCCReference Include="CmnFunc2.pas"/>
+			<DCCReference Include="CompFunc.pas"/>
 			<DCCReference Include="CompMsgs.pas"/>
 			<DCCReference Include="CompInt.pas"/>
 			<DCCReference Include="CompOptions.pas">

--- a/Projects/Compile.pas
+++ b/Projects/Compile.pas
@@ -9206,14 +9206,14 @@ begin
   SetupCompiler.SourceDir := Params.SourcePath;
 end;
 
-function GetIncludedFilenames(SetupCompiler: TSetupCompiler): String;
+function EncodeIncludedFilenames(const IncludedFilenames: TStringList): String;
 var
   S: String;
   I: Integer;
 begin
   S := '';
-  for I := 0 to SetupCompiler.PreprocIncludedFilenames.Count-1 do
-   S := S + SetupCompiler.PreprocIncludedFilenames[I] + #0;
+  for I := 0 to IncludedFilenames.Count-1 do
+   S := S + IncludedFilenames[I] + #0;
   Result := S;
 end;
 
@@ -9289,7 +9289,7 @@ begin
       SetupCompiler.Compile;
     except
       Result := isceError;
-      S := GetIncludedFilenames(SetupCompiler);
+      S := EncodeIncludedFilenames(SetupCompiler.PreprocIncludedFilenames);
       Data.IncludedFilenames := PChar(S);
       Params.CallbackProc(iscbNotifyIncludedFiles, Data, Params.AppData);
       Data.ErrorMsg := nil;
@@ -9308,7 +9308,7 @@ begin
         raise;
       Exit;
     end;
-    S := GetIncludedFilenames(SetupCompiler);
+    S := EncodeIncludedFilenames(SetupCompiler.PreprocIncludedFilenames);
     Data.IncludedFilenames := PChar(S);
     Params.CallbackProc(iscbNotifyIncludedFiles, Data, Params.AppData);
     Data.OutputExeFilename := PChar(SetupCompiler.ExeFilename);
@@ -9344,7 +9344,7 @@ begin
         raise;
       Exit;
     end;
-    S := GetIncludedFilenames(SetupCompiler);
+    S := EncodeIncludedFilenames(SetupCompiler.PreprocIncludedFilenames);
     Data.IncludedFilenames := PChar(S);
     Params.CallbackProc(iscbNotifyIncludedFiles, Data, Params.AppData);
   finally

--- a/Projects/Compile.pas
+++ b/Projects/Compile.pas
@@ -26,8 +26,6 @@ uses
 
 function ISCompileScript(const Params: TCompileScriptParamsEx;
   const PropagateExceptions: Boolean): Integer;
-function ISScanScript(const Params: TCompileScriptParamsEx;
-  const PropagateExceptions: Boolean): Integer;
 function ISGetVersion: PCompilerVersionInfo;
 
 type
@@ -326,7 +324,6 @@ type
     procedure ProcessWildcardsParameter(const ParamData: String;
       const AWildcards: TStringList; const TooLongMsg: String);
     procedure ReadDefaultMessages;
-    function ReadMainScriptLines: TLowFragStringList;
 {$IFDEF UNICODE}
     procedure ReadMessagesFromFilesPre(const AFiles: String; const ALangIndex: Integer);
 {$ENDIF}
@@ -363,7 +360,6 @@ type
     destructor Destroy; override;
     procedure AddSignTool(const Name, Command: String);
     procedure Compile;
-    procedure Scan;
   end;
 
 var
@@ -1049,19 +1045,17 @@ end;
 type
   EBuiltinPreprocessScriptError = class(Exception);
 
-function BuiltinPreprocessScriptEx(var Params: TPreprocessScriptParams; const Scanning: Boolean): Integer; stdcall;
+function BuiltinPreprocessScript(var Params: TPreprocessScriptParams): Integer; stdcall;
 var
   IncludeStack: TStringList;
 
-  procedure RaiseErrorIfNotScanning(const LineFilename: String; const LineNumber: Integer;
+  procedure RaiseError(const LineFilename: String; const LineNumber: Integer;
     const Msg: String);
   begin
-    if not Scanning then begin
-      Params.ErrorProc(Params.CompilerData, PChar(Msg), PChar(LineFilename),
-        LineNumber, 0);
-      { Note: This exception is caught and translated into ispePreprocessError }
-      raise EBuiltinPreprocessScriptError.Create('BuiltinPreprocessScript error');
-    end;
+    Params.ErrorProc(Params.CompilerData, PChar(Msg), PChar(LineFilename),
+      LineNumber, 0);
+    { Note: This exception is caught and translated into ispePreprocessError }
+    raise EBuiltinPreprocessScriptError.Create('BuiltinPreprocessScript error');
   end;
 
   procedure ProcessLines(const Filename: String; const FileHandle: TPreprocFileHandle);
@@ -1074,21 +1068,17 @@ var
     FileHandle: TPreprocFileHandle;
   begin
     { Check if it's a recursive include }
-    for I := 0 to IncludeStack.Count-1 do begin
-      if PathCompare(IncludeStack[I], IncludeFilename) = 0 then begin
-          RaiseErrorIfNotScanning(LineFilename, LineNumber, Format(SCompilerRecursiveInclude,
-            [IncludeFilename]));
-          Exit;
-      end;
-    end;
+    for I := 0 to IncludeStack.Count-1 do
+      if PathCompare(IncludeStack[I], IncludeFilename) = 0 then
+        RaiseError(LineFilename, LineNumber, Format(SCompilerRecursiveInclude,
+          [IncludeFilename]));
 
     FileHandle := Params.LoadFileProc(Params.CompilerData,
       PChar(IncludeFilename), PChar(LineFilename), LineNumber, 0);
     if FileHandle < 0 then begin
       { Note: The message here shouldn't be seen as LoadFileProc should have
         already called ErrorProc itself }
-      RaiseErrorIfNotScanning(LineFilename, LineNumber, 'LoadFileProc failed');
-      Exit;
+      RaiseError(LineFilename, LineNumber, 'LoadFileProc failed');
     end;
     ProcessLines(IncludeFilename, FileHandle);
   end;
@@ -1098,18 +1088,13 @@ var
   var
     Dir, IncludeFilename: String;
   begin
-    { Note: SelectPreprocessor blanks any #preproc lines }
     if Copy(D, 1, Length('include')) = 'include' then begin
       Delete(D, 1, Length('include'));
-      if (D = '') or (D[1] > ' ') then begin
-        RaiseErrorIfNotScanning(LineFilename, LineNumber, SCompilerInvalidDirective);
-        Exit;
-      end;
+      if (D = '') or (D[1] > ' ') then
+        RaiseError(LineFilename, LineNumber, SCompilerInvalidDirective);
       D := TrimLeft(D);
-      if (Length(D) < 3) or (D[1] <> '"') or (PathLastChar(D)^ <> '"') then begin
-        RaiseErrorIfNotScanning(LineFilename, LineNumber, SCompilerInvalidDirective);
-        Exit;
-      end;
+      if (Length(D) < 3) or (D[1] <> '"') or (PathLastChar(D)^ <> '"') then
+        RaiseError(LineFilename, LineNumber, SCompilerInvalidDirective);
       if LineFilename = '' then
         Dir := Params.SourcePath
       else
@@ -1119,16 +1104,14 @@ var
       if IncludeFilename = '' then begin
         { Note: The message here shouldn't be seen as PrependDirNameProc
           should have already called ErrorProc itself }
-        RaiseErrorIfNotScanning(LineFilename, LineNumber, 'PrependDirNameProc failed');
-        Exit;
+        RaiseError(LineFilename, LineNumber, 'PrependDirNameProc failed');
       end;
-      if Assigned(Params.StatusProc) then
-        Params.StatusProc(Params.CompilerData,
-          PChar(Format(SBuiltinPreprocessStatusIncludingFile, [IncludeFilename])), False);
+      Params.StatusProc(Params.CompilerData,
+        PChar(Format(SBuiltinPreprocessStatusIncludingFile, [IncludeFilename])), False);
       ProcessLinesFromFile(LineFilename, LineNumber, PathExpand(IncludeFilename));
     end
     else
-      RaiseErrorIfNotScanning(LineFilename, LineNumber, SCompilerInvalidDirective);
+      RaiseError(LineFilename, LineNumber, SCompilerInvalidDirective);
   end;
 
   procedure ProcessLines(const Filename: String; const FileHandle: TPreprocFileHandle);
@@ -1146,7 +1129,7 @@ var
       SkipWhitespace(L);
       if L^ = '#' then
         ProcessDirective(Filename, I + 1, L + 1)
-      else if Assigned(Params.LineOutProc) then
+      else
         Params.LineOutProc(Params.CompilerData, PChar(Filename), I + 1,
           LineText);
       Inc(I);
@@ -1174,11 +1157,6 @@ begin
     if not(ExceptObject is EBuiltinPreprocessScriptError) then
       raise;
   end;
-end;
-
-function BuiltinPreprocessScript(var Params: TPreprocessScriptParams): Integer; stdcall;
-begin
-  Result := BuiltinPreprocessScriptEx(Params, False);
 end;
 
 { TCompressionHandler }
@@ -1815,7 +1793,6 @@ type
   PPreCompilerData = ^TPreCompilerData;
   TPreCompilerData = record
     Compiler: TSetupCompiler;
-    Scanning: Boolean;
     InFiles: TStringList;
     OutLines: TScriptFileLines;
     AnsiConvertCodePage: Cardinal;
@@ -1859,8 +1836,7 @@ begin
   Lines := TLowFragStringList.Create;
   try
     if FromPreProcessor then begin
-      if not Data.Scanning then
-        Data.Compiler.AddStatus(Format(SCompilerStatusReadingInFile, [Filename]));
+      Data.Compiler.AddStatus(Format(SCompilerStatusReadingInFile, [Filename]));
       Data.Compiler.PreprocIncludedFilenames.Add(Filename);
     end;
     F := TTextFileReader.Create(Filename, fdOpenExisting, faRead, fsRead);
@@ -1968,31 +1944,31 @@ begin
   end;
 end;
 
-function TSetupCompiler.ReadMainScriptLines: TLowFragStringList;
-var
-  Reset: Boolean;
-  Data: TCompilerCallbackData;
-begin
-  Result := TLowFragStringList.Create;
-  try
-    Reset := True;
-    while True do begin
-      Data.Reset := Reset;
-      Data.LineRead := nil;
-      DoCallback(iscbReadScript, Data);
-      if Data.LineRead = nil then
-        Break;
-      Result.Add(Data.LineRead);
-      Reset := False;
-    end;
-  except
-    Result.Free;
-    raise;
-  end;
-end;
-
 function TSetupCompiler.ReadScriptFile(const Filename: String;
   const UseCache: Boolean; const AnsiConvertCodePage: Cardinal): TScriptFileLines;
+
+  function ReadMainScriptLines: TLowFragStringList;
+  var
+    Reset: Boolean;
+    Data: TCompilerCallbackData;
+  begin
+    Result := TLowFragStringList.Create;
+    try
+      Reset := True;
+      while True do begin
+        Data.Reset := Reset;
+        Data.LineRead := nil;
+        DoCallback(iscbReadScript, Data);
+        if Data.LineRead = nil then
+          Break;
+        Result.Add(Data.LineRead);
+        Reset := False;
+      end;
+    except
+      Result.Free;
+      raise;
+    end;
+  end;
 
   function SelectPreprocessor(const Lines: TLowFragStringList): TPreprocessScriptProc;
   var
@@ -9147,38 +9123,6 @@ begin
   end;
 end;
 
-procedure TSetupCompiler.Scan;
-var
-  Params: TPreprocessScriptParams;
-  Data: TPreCompilerData;
-  I: Integer;
-begin
-  FillChar(Params, SizeOf(Params), 0);
-  Params.Size := SizeOf(Params);
-  Params.InterfaceVersion := 2;
-  Params.CompilerBinVersion := SetupBinVersion;
-  Params.Filename := '';
-  Params.SourcePath := PChar(SourceDir);
-  Params.CompilerPath := PChar(CompilerDir);
-  Params.CompilerData := @Data;
-  Params.LoadFileProc := PreLoadFileProc;
-  Params.LineInProc := PreLineInProc;
-  Params.PrependDirNameProc := PrePrependDirNameProc;
-
-  FillChar(Data, SizeOf(Data), 0);
-  Data.Compiler := Self;
-  Data.Scanning := True;
-  Data.InFiles := TStringList.Create;
-  try
-    Data.InFiles.AddObject('', ReadMainScriptLines);
-    BuiltinPreprocessScriptEx(Params, True);
-  finally
-    for I := Data.InFiles.Count-1 downto 0 do
-      Data.InFiles.Objects[I].Free;
-    Data.InFiles.Free;
-  end;
-end;
-
 { Interface helper functions }
 
 function CheckParams(const Params: TCompileScriptParamsEx): Boolean;
@@ -9282,7 +9226,7 @@ begin
     try
       SetupCompiler.Compile;
     except
-      Result := isceFailure;
+      Result := isceCompileFailure;
       S := EncodeIncludedFilenames(SetupCompiler.PreprocIncludedFilenames);
       Data.IncludedFilenames := PChar(S);
       Params.CallbackProc(iscbNotifyIncludedFiles, Data, Params.AppData);
@@ -9309,38 +9253,6 @@ begin
     Data.DebugInfo := SetupCompiler.DebugInfo.Memory;
     Data.DebugInfoSize := SetupCompiler.DebugInfo.Size;
     Params.CallbackProc(iscbNotifySuccess, Data, Params.AppData);
-  finally
-    SetupCompiler.Free;
-  end;
-end;
-
-function ISScanScript(const Params: TCompileScriptParamsEx;
-  const PropagateExceptions: Boolean): Integer;
-var
-  SetupCompiler: TSetupCompiler;
-  Data: TCompilerCallbackData;
-  S: String;
-begin
-  if not CheckParams(Params) then begin
-    Result := isceInvalidParam;
-    Exit;
-  end;
-  SetupCompiler := TSetupCompiler.Create(nil);
-  try
-    InitializeSetupCompiler(SetupCompiler, Params);
-
-    Result := isceNoError;
-    try
-      SetupCompiler.Scan;
-    except
-      Result := isceFailure;
-      if PropagateExceptions then
-        raise;
-      Exit;
-    end;
-    S := EncodeIncludedFilenames(SetupCompiler.PreprocIncludedFilenames);
-    Data.IncludedFilenames := PChar(S);
-    Params.CallbackProc(iscbNotifyIncludedFiles, Data, Params.AppData);
   finally
     SetupCompiler.Free;
   end;

--- a/Projects/Compile.pas
+++ b/Projects/Compile.pas
@@ -9150,7 +9150,7 @@ var
   SetupCompiler: TSetupCompiler;
   P: PChar;
   Data: TCompilerCallbackData;
-  S: String;
+  S, S2: String;
   P2: Integer;
 begin
   if ((Params.Size <> SizeOf(Params)) and
@@ -9232,7 +9232,8 @@ begin
           pointer if the string is empty }
         Data.ErrorFilename := Pointer(SetupCompiler.ParseFilename);
         Data.ErrorLine := SetupCompiler.LineNumber;
-        Data.IncludedFilenamesSoFar := PChar(GetIncludedFilenames(SetupCompiler));
+        S2 := GetIncludedFilenames(SetupCompiler);
+        Data.IncludedFilenamesSoFar := PChar(S2);
       end;
       Params.CallbackProc(iscbNotifyError, Data, Params.AppData);
       if PropagateExceptions then
@@ -9242,7 +9243,8 @@ begin
     Data.OutputExeFilename := PChar(SetupCompiler.ExeFilename);
     Data.DebugInfo := SetupCompiler.DebugInfo.Memory;
     Data.DebugInfoSize := SetupCompiler.DebugInfo.Size;
-    Data.IncludedFilenames := PChar(GetIncludedFilenames(SetupCompiler));
+    S := GetIncludedFilenames(SetupCompiler);
+    Data.IncludedFilenames := PChar(S);
     Params.CallbackProc(iscbNotifySuccess, Data, Params.AppData);
   finally
     SetupCompiler.Free;

--- a/Projects/Compile.pas
+++ b/Projects/Compile.pas
@@ -9134,12 +9134,24 @@ end;
 
 function ISCompileScript(const Params: TCompileScriptParamsEx;
   const PropagateExceptions: Boolean): Integer;
+
+  function GetIncludedFilenames(SetupCompiler: TSetupCompiler): String;
+  var
+    S: String;
+    I: Integer;
+  begin
+    S := '';
+    for I := 0 to SetupCompiler.PreprocIncludedFilenames.Count-1 do
+     S := S + SetupCompiler.PreprocIncludedFilenames[I] + #0;
+    Result := S;
+  end;
+
 var
   SetupCompiler: TSetupCompiler;
   P: PChar;
   Data: TCompilerCallbackData;
   S: String;
-  P2, I: Integer;
+  P2: Integer;
 begin
   if ((Params.Size <> SizeOf(Params)) and
       (Params.Size <> SizeOf(TCompileScriptParams))) or
@@ -9220,6 +9232,7 @@ begin
           pointer if the string is empty }
         Data.ErrorFilename := Pointer(SetupCompiler.ParseFilename);
         Data.ErrorLine := SetupCompiler.LineNumber;
+        Data.IncludedFilenamesSoFar := PChar(GetIncludedFilenames(SetupCompiler));
       end;
       Params.CallbackProc(iscbNotifyError, Data, Params.AppData);
       if PropagateExceptions then
@@ -9229,10 +9242,7 @@ begin
     Data.OutputExeFilename := PChar(SetupCompiler.ExeFilename);
     Data.DebugInfo := SetupCompiler.DebugInfo.Memory;
     Data.DebugInfoSize := SetupCompiler.DebugInfo.Size;
-    S := '';
-    for I := 0 to SetupCompiler.PreprocIncludedFilenames.Count-1 do
-     S := S + SetupCompiler.PreprocIncludedFilenames[I] + #0;
-    Data.IncludedFilenames := PChar(S);
+    Data.IncludedFilenames := PChar(GetIncludedFilenames(SetupCompiler));
     Params.CallbackProc(iscbNotifySuccess, Data, Params.AppData);
   finally
     SetupCompiler.Free;

--- a/Projects/ISCC.dpr
+++ b/Projects/ISCC.dpr
@@ -611,7 +611,7 @@ begin
     {$ENDIF}
     case Res of
       isceNoError: ;
-      isceError: begin
+      isceFailure: begin
           ExitCode := 2;
           WriteStdErr('Compile aborted.', True);
         end;

--- a/Projects/ISCC.dpr
+++ b/Projects/ISCC.dpr
@@ -611,7 +611,7 @@ begin
     {$ENDIF}
     case Res of
       isceNoError: ;
-      isceFailure: begin
+      isceCompileFailure: begin
           ExitCode := 2;
           WriteStdErr('Compile aborted.', True);
         end;

--- a/Projects/ISCC.dpr
+++ b/Projects/ISCC.dpr
@@ -611,7 +611,7 @@ begin
     {$ENDIF}
     case Res of
       isceNoError: ;
-      isceCompileFailure: begin
+      isceError: begin
           ExitCode := 2;
           WriteStdErr('Compile aborted.', True);
         end;

--- a/Projects/ISCmplr.dpr
+++ b/Projects/ISCmplr.dpr
@@ -52,6 +52,7 @@ type
     LastLineRead: String;
   end;
 
+{ Does not support iscbNotifyIncludedFiles }
 function WrapperCallbackProc(Code: Integer; var Data: TCompilerCallbackData;
   AppData: Longint): Integer;
 stdcall;

--- a/Projects/ISCmplr.dpr
+++ b/Projects/ISCmplr.dpr
@@ -44,12 +44,6 @@ begin
   Result := ISCompileScript(Params, False);
 end;
 
-function ISDllScanScript(const Params: TCompileScriptParamsEx): Integer;
-stdcall;
-begin
-  Result := ISScanScript(Params, False);
-end;
-
 type
   PWrapperData = ^TWrapperData;
   TWrapperData = record
@@ -157,7 +151,6 @@ end;
 exports
   ISDllCompileScript name 'ISDllCompileScriptW',
   ISDllCompileScriptA name 'ISDllCompileScript',
-  ISDllScanScript name 'ISDllScanScriptW',
   ISDllGetVersion;
 
 begin

--- a/whatsnew.htm
+++ b/whatsnew.htm
@@ -42,11 +42,12 @@ For conditions of distribution and use, see <a href="https://jrsoftware.org/file
 <p><span class="head2">Compiler IDE updates</span></p>
 <p>Various improvements have been made to the Compiler IDE:</p>
 <ul>
+  <li>The Compiler IDE now automatically opens <tt>#include</tt> files in tabs which allow you to edit these files from within the Compiler IDE. The list of <tt>#include</tt> files is updated after opening a new main file and after each compilation. This can be turned off in the options.</li>
+  <li>If <tt>#include</tt> files are modified since last compile, the script is now automatically re-compiled before running it. This works even if the option to automatically open <tt>#include</tt> files is turned off.</li>
   <li><a href="https://i.imgur.com/wHoJ3FG.png">Improved highlighting</a> for the [CustomMessages] and [Messages] sections.</li>
   <li>Added new <a href="https://i.imgur.com/c9wGM3M.png">MessageBox Designer</a> menu item to the Tools menu to design and insert MsgBox or TaskDialogMsgBox calls for the [Code] section.</li>
   <li>Added buttons to the Welcome dialog to <a href="https://jrsoftware.org/isdonate.php">Donate</a> to support Inno Setup (Thank you!) and to <a href="https://jrsoftware.org/ismail.php">Subscribe</a> to the Inno Setup Mailing List to be notified by e-mail of new Inno Setup releases.</li>
   <li>The Run Parameters dialog now shows a list of most recently used parameters.</li>
-  <li>If <tt>#include</tt>-ed files are modified since last compile, the script is now automatically re-compiled before running it.</li>
 </ul>
 <p><span class="head2">Built-in download support for [Code]</span></p>
 <p>Pascal Scripting now supports downloading files and checking SHA-256 hashes:</p>

--- a/whatsnew.htm
+++ b/whatsnew.htm
@@ -42,7 +42,7 @@ For conditions of distribution and use, see <a href="https://jrsoftware.org/file
 <p><span class="head2">Compiler IDE updates</span></p>
 <p>Various improvements have been made to the Compiler IDE:</p>
 <ul>
-  <li>The Compiler IDE now automatically opens <tt>#include</tt> files in tabs which allow you to edit these files from within the Compiler IDE. The list of <tt>#include</tt> files is updated after opening a new main file and after each compilation. This can be turned off in the options. If the option is not turned off, a new Save All menu item is added to the Files menu.</li>
+  <li>The Compiler IDE now automatically opens (up to 10) <tt>#include</tt> files in tabs which allow you to edit these files from within the Compiler IDE. The list of <tt>#include</tt> files is updated after opening a new main file and after each compilation. This can be turned off in the options. If the option is not turned off, a new Save All menu item is added to the Files menu.</li>
   <li>If <tt>#include</tt> files are modified since last compile, the script is now automatically re-compiled before running it. This works even if the option to automatically open <tt>#include</tt> files is turned off.</li>
   <li><a href="https://i.imgur.com/wHoJ3FG.png">Improved highlighting</a> for the [CustomMessages] and [Messages] sections.</li>
   <li>Added new <a href="https://i.imgur.com/c9wGM3M.png">MessageBox Designer</a> menu item to the Tools menu to design and insert MsgBox or TaskDialogMsgBox calls for the [Code] section.</li>

--- a/whatsnew.htm
+++ b/whatsnew.htm
@@ -42,7 +42,7 @@ For conditions of distribution and use, see <a href="https://jrsoftware.org/file
 <p><span class="head2">Compiler IDE updates</span></p>
 <p>Various improvements have been made to the Compiler IDE:</p>
 <ul>
-  <li>The Compiler IDE now automatically opens <tt>#include</tt> files in tabs which allow you to edit these files from within the Compiler IDE. The list of <tt>#include</tt> files is updated after opening a new main file and after each compilation. This can be turned off in the options.</li>
+  <li>The Compiler IDE now automatically opens <tt>#include</tt> files in tabs which allow you to edit these files from within the Compiler IDE. The list of <tt>#include</tt> files is updated after opening a new main file and after each compilation. This can be turned off in the options. If the option is not turned off, a new Save All menu item is added to the Files menu.</li>
   <li>If <tt>#include</tt> files are modified since last compile, the script is now automatically re-compiled before running it. This works even if the option to automatically open <tt>#include</tt> files is turned off.</li>
   <li><a href="https://i.imgur.com/wHoJ3FG.png">Improved highlighting</a> for the [CustomMessages] and [Messages] sections.</li>
   <li>Added new <a href="https://i.imgur.com/c9wGM3M.png">MessageBox Designer</a> menu item to the Tools menu to design and insert MsgBox or TaskDialogMsgBox calls for the [Code] section.</li>


### PR DESCRIPTION
The Compiler IDE now automatically opens (up to 10) `#include` files in tabs which allow you to edit these files from within the Compiler IDE. The list of `#include` files is updated after opening a new main file and after each compilation. This can be turned off in the options. If the option is not turned off, a new Save All menu item is added to the Files menu.