### PR TITLE
Change Corsican translation for current 6.1.0+

### DIFF
--- a/Files/Languages/Corsican.isl
+++ b/Files/Languages/Corsican.isl
@@ -13,6 +13,7 @@
 ; E-mail: Patrick.Santa-Maria[at]LaPoste.Net
 ;
 ; Changes:
+; November 14th, 2020 - Changes to current version 6.1.0+
 ; July 25th, 2020 - Update to version 6.1.0+
 ; July 1st, 2020 - Update to version 6.0.6+
 ; October 6th, 2019 - Update to version 6.0.3+
@@ -53,23 +54,23 @@ ConfirmTitle=Cunfirmà
 ErrorTitle=Sbagliu
 
 ; *** SetupLdr messages
-SetupLdrStartupMessage=St’assistente hà da installà %1. Vulete cuntinuà ?
+SetupLdrStartupMessage=St’assistente hà da installà %1. Vulete cuntinuà ?
 LdrCannotCreateTemp=Impussibule di creà un cartulare timpurariu. Assistente d’installazione interrottu
 LdrCannotExecTemp=Impussibule d’eseguisce u schedariu in u cartulare timpurariu. Assistente d’installazione interrottu
 HelpTextNote=
 
 ; *** Startup error messages
-LastErrorMessage=%1.%n%nSbagliu %2 : %3
+LastErrorMessage=%1.%n%nSbagliu %2 : %3
 SetupFileMissing=U schedariu %1 manca in u cartulare d’installazione. Ci vole à currege u penseru o ottene una nova copia di u prugramma.
 SetupFileCorrupt=I schedarii d’installazione sò alterati. Ci vole à ottene una nova copia di u prugramma.
 SetupFileCorruptOrWrongVer=I schedarii d’installazione sò alterati, o sò incumpatibule cù sta versione di l’assistente. Ci vole à currege u penseru o ottene una nova copia di u prugramma.
-InvalidParameter=Un parametru micca accettevule hè statu passatu in a linea di cumanda :%n%n%1
+InvalidParameter=Un parametru micca accettevule hè statu passatu in a linea di cumanda :%n%n%1
 SetupAlreadyRunning=L’assistente d’installazione hè dighjà in corsu.
 WindowsVersionNotSupported=Stu prugramma ùn pò micca funziunà cù a versione di Windows installata nant’à st’urdinatore.
 WindowsServicePackRequired=Stu prugramma richiede %1 Service Pack %2 o più recente.
 NotOnThisPlatform=Stu prugramma ùn funzionerà micca cù %1.
 OnlyOnThisPlatform=Stu prugramma deve funzionà cù %1.
-OnlyOnTheseArchitectures=Stu prugramma pò solu esse installatu nant’à e versioni di Windows fatte apposta per st’architetture di prucessore :%n%n%1
+OnlyOnTheseArchitectures=Stu prugramma pò solu esse installatu nant’à e versioni di Windows fatte apposta per st’architetture di prucessore :%n%n%1
 WinVersionTooLowError=Stu prugramma richiede %1 versione %2 o più recente.
 WinVersionTooHighError=Stu prugramma ùn pò micca esse installatu nant’à %1 version %2 o più recente.
 AdminPrivilegesRequired=Ci vole à esse cunnettu cum’è un amministratore quandu voi installate stu prugramma.
@@ -93,10 +94,10 @@ ErrorTooManyFilesInDir=Impussibule di creà un schedariu in u cartulare « %1 »
 
 ; *** Setup common messages
 ExitSetupTitle=Compie l’assistente
-ExitSetupMessage=L’assistente ùn hè micca compiu bè. S’è voi escite avà, u prugramma ùn serà micca installatu.%n%nPudete impiegà l’assistente torna un altra volta per compie l’installazione.%n%nCompie l’assistente ?
+ExitSetupMessage=L’assistente ùn hè micca compiu bè. S’è voi escite avà, u prugramma ùn serà micca installatu.%n%nPudete impiegà l’assistente torna un altra volta per compie l’installazione.%n%nCompie l’assistente ?
 AboutSetupMenuItem=&Apprupositu di l’assistente…
 AboutSetupTitle=Apprupositu di l’assistente
-AboutSetupMessage=%1 versione %2%n%3%n%n%1 pagina d’accolta :%n%4
+AboutSetupMessage=%1 versione %2%n%3%n%n%1 pagina d’accolta :%n%4
 AboutSetupNote=
 TranslatorNote=Traduzzione in lingua corsa da Patriccollu di Santa Maria è Sichè
 
@@ -134,7 +135,7 @@ WelcomeLabel2=Quessu installerà [name/ver] nant’à l’urdinatore.%n%nHè ric
 WizardPassword=Parolla d’entrata
 PasswordLabel1=L’installazione hè prutetta da una parolla d’entrata.
 PasswordLabel3=Ci vole à pruvede a parolla d’entrata, eppò sceglie Seguente per cuntinuà. E parolle d’entrata ponu cuntene maiuscule è minuscule.
-PasswordEditLabel=&Parolla d’entrata :
+PasswordEditLabel=&Parolla d’entrata :
 IncorrectPassword=A parolla d’entrata pruvista ùn hè micca curretta. Ci vole à pruvà torna.
 
 ; *** "License Agreement" wizard page
@@ -155,42 +156,42 @@ InfoAfterClickLabel=Quandu site prontu à cuntinuà cù l’assistente, sciglite
 ; *** "User Information" wizard page
 WizardUserInfo=Infurmazioni di l’utilizatore
 UserInfoDesc=Ci vole à scrive e vostre infurmazioni.
-UserInfoName=&Nome d’utilizatore :
-UserInfoOrg=&Urganismu :
-UserInfoSerial=&Numeru di Seria :
+UserInfoName=&Nome d’utilizatore :
+UserInfoOrg=&Urganismu :
+UserInfoSerial=&Numeru di Seria :
 UserInfoNameRequired=Ci vole à scrive un nome.
 
 ; *** "Select Destination Location" wizard page
 WizardSelectDir=Selezziunà u locu di destinazione
-SelectDirDesc=Induve [name] deve esse installatu ?
+SelectDirDesc=Induve [name] deve esse installatu ?
 SelectDirLabel3=L’assistente installerà [name] in stu cartulare.
 SelectDirBrowseLabel=Per cuntinuà, sceglie Seguente. S’è voi preferisce selezziunà un altru cartulare, sciglite Sfuglià.
 DiskSpaceGBLabel=Hè richiestu omancu [gb] Go di spaziu liberu di discu.
 DiskSpaceMBLabel=Hè richiestu omancu [mb] Mo di spaziu liberu di discu.
 CannotInstallToNetworkDrive=L’assistente ùn pò micca installà nant’à un discu di a reta.
 CannotInstallToUNCPath=L’assistente ùn pò micca installà in un chjassu UNC.
-InvalidPath=Ci vole à scrive un chjassu cumplettu cù a lettera di u lettore ; per indettu :%n%nC:\APP%n%no un chjassu UNC in a forma :%n%n\\servitore\spartu
+InvalidPath=Ci vole à scrive un chjassu cumplettu cù a lettera di u lettore ; per indettu :%n%nC:\APP%n%no un chjassu UNC in a forma :%n%n\\servitore\spartu
 InvalidDrive=U lettore o u chjassu UNC spartu ùn esiste micca o ùn hè micca accessibule. Ci vole à selezziunane un altru.
 DiskSpaceWarningTitle=Ùn basta u spaziu discu
-DiskSpaceWarning=L’assistente richiede omancu %1 Ko di spaziu liberu per installà, ma u lettore selezziunatu hà solu %2 Ko dispunibule.%n%nVulete cuntinuà quantunque ?
+DiskSpaceWarning=L’assistente richiede omancu %1 Ko di spaziu liberu per installà, ma u lettore selezziunatu hà solu %2 Ko dispunibule.%n%nVulete cuntinuà quantunque ?
 DirNameTooLong=U nome di cartulare o u chjassu hè troppu longu.
 InvalidDirName=U nome di cartulare ùn hè micca accettevule.
-BadDirName32=I nomi di cartulare ùn ponu micca cuntene sti caratteri :%n%n%1
+BadDirName32=I nomi di cartulare ùn ponu micca cuntene sti caratteri :%n%n%1
 DirExistsTitle=Cartulare esistente
-DirExists=U cartulare :%n%n%1%n%nesiste dighjà. Vulete installà in stu cartulare quantunque ?
+DirExists=U cartulare :%n%n%1%n%nesiste dighjà. Vulete installà in stu cartulare quantunque ?
 DirDoesntExistTitle=Cartulare inesistente
-DirDoesntExist=U cartulare :%n%n%1%n%nùn esiste micca. Vulete chì stu cartulare sia creatu ?
+DirDoesntExist=U cartulare :%n%n%1%n%nùn esiste micca. Vulete chì stu cartulare sia creatu ?
 
 ; *** "Select Components" wizard page
 WizardSelectComponents=Selezzione di cumpunenti
-SelectComponentsDesc=Chì cumpunenti devenu esse installati ?
+SelectComponentsDesc=Chì cumpunenti devenu esse installati ?
 SelectComponentsLabel2=Selezziunà i cumpunenti à installà ; deselezziunà quelli ch’ùn devenu micca esse installati. Sceglie Seguente quandu site prontu à cuntinuà.
 FullInstallation=Installazione sana
 ; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
 CompactInstallation=Installazione cumpatta
 CustomInstallation=Installazione persunalizata
 NoUninstallWarningTitle=Cumpunenti esistenti
-NoUninstallWarning=L’assistente hà vistu chì sti cumpunenti sò dighjà installati nant’à l’urdinatore :%n%n%1%n%nDeselezziunà sti cumpunenti ùn i disinstallerà micca.%n%nVulete cuntinuà quantunque ?
+NoUninstallWarning=L’assistente hà vistu chì sti cumpunenti sò dighjà installati nant’à l’urdinatore :%n%n%1%n%nDeselezziunà sti cumpunenti ùn i disinstallerà micca.%n%nVulete cuntinuà quantunque ?
 ComponentSize1=%1 Ko
 ComponentSize2=%1 Mo
 ComponentsDiskSpaceGBLabel=A selezzione attuale richiede omancu [gb] Go di spaziu liberu nant’à u discu.
@@ -198,18 +199,18 @@ ComponentsDiskSpaceMBLabel=A selezzione attuale richiede omancu [mb] Mo di spazi
 
 ; *** "Select Additional Tasks" wizard page
 WizardSelectTasks=Selezziunà trattamenti addizziunali
-SelectTasksDesc=Chì trattamenti addizziunali vulete fà ?
+SelectTasksDesc=Chì trattamenti addizziunali vulete fà ?
 SelectTasksLabel2=Selezziunà i trattamenti addizziunali chì l’assistente deve fà durante l’installazione di [name], eppò sceglie Seguente.
 
 ; *** "Select Start Menu Folder" wizard page
 WizardSelectProgramGroup=Selezzione di u cartulare di u listinu « Démarrer »
-SelectStartMenuFolderDesc=Induve l’assistente deve piazzà l’accurtatoghji di u prugramma ?
+SelectStartMenuFolderDesc=Induve l’assistente deve piazzà l’accurtatoghji di u prugramma ?
 SelectStartMenuFolderLabel3=L’assistente piazzerà l’accurtatoghji di u prugramma in stu cartulare di u listinu « Démarrer ».
 SelectStartMenuFolderBrowseLabel=Per cuntinuà, sceglie Seguente. S’è voi preferisce selezziunà un altru cartulare, sciglite Sfuglià.
 MustEnterGroupName=Ci vole à scrive un nome di cartulare.
 GroupNameTooLong=U nome di cartulare o u chjassu hè troppu longu.
 InvalidGroupName=U nome di cartulare ùn hè micca accettevule.
-BadGroupName=U nome di u cartulare ùn pò micca cuntene alcunu di sti caratteri :%n%n%1
+BadGroupName=U nome di u cartulare ùn pò micca cuntene alcunu di sti caratteri :%n%n%1
 NoProgramGroupCheck2=Ùn creà &micca di cartulare in u listinu « Démarrer »
 
 ; *** "Ready to Install" wizard page
@@ -217,24 +218,24 @@ WizardReady=Prontu à Installà
 ReadyLabel1=Avà l’assistente hè prontu à principià l’installazione di [name] nant’à l’urdinatore.
 ReadyLabel2a=Sceglie Installà per cuntinuà l’installazione, o nant’à Precedente per rivede o cambià qualchì preferenza.
 ReadyLabel2b=Sceglie Installà per cuntinuà l’installazione.
-ReadyMemoUserInfo=Infurmazioni di l’utilizatore :
-ReadyMemoDir=Cartulare d’installazione :
-ReadyMemoType=Tipu d’installazione :
-ReadyMemoComponents=Cumpunenti selezziunati :
-ReadyMemoGroup=Cartulare di u listinu « Démarrer » :
-ReadyMemoTasks=Trattamenti addizziunali :
+ReadyMemoUserInfo=Infurmazioni di l’utilizatore :
+ReadyMemoDir=Cartulare d’installazione :
+ReadyMemoType=Tipu d’installazione :
+ReadyMemoComponents=Cumpunenti selezziunati :
+ReadyMemoGroup=Cartulare di u listinu « Démarrer » :
+ReadyMemoTasks=Trattamenti addizziunali :
 
 ; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
 DownloadingLabel=Scaricamentu di i schedarii addiziunali…
 ButtonStopDownload=&Piantà u scaricamentu
-StopDownload=Site sicuru di vulè piantà u scaricamentu ?
+StopDownload=Site sicuru di vulè piantà u scaricamentu ?
 ErrorDownloadAborted=Scaricamentu interrottu
-ErrorDownloadFailed=Scaricamentu fiascu : %1 %2
-ErrorDownloadSizeFailed=Fiascu per ottene a dimensione : %1 %2
-ErrorFileHash1=Fiascu di u tazzeghju di u schedariu : %1
-ErrorFileHash2=Tazzeghju di u schedariu inaccettevule : aspettatu %1, trovu %2
-ErrorProgress=Prugressione inaccettevule : %1 di %2
-ErrorFileSize=Dimensione di u schedariu inaccettevule : aspettatu %1, trovu %2
+ErrorDownloadFailed=Scaricamentu fiascu : %1 %2
+ErrorDownloadSizeFailed=Fiascu per ottene a dimensione : %1 %2
+ErrorFileHash1=Fiascu di u tazzeghju di u schedariu : %1
+ErrorFileHash2=Tazzeghju di u schedariu inaccettevule : aspettatu %1, trovu %2
+ErrorProgress=Prugressione inaccettevule : %1 di %2
+ErrorFileSize=Dimensione di u schedariu inaccettevule : aspettatu %1, trovu %2
 
 ; *** "Preparing to Install" wizard page
 WizardPreparing=Preparazione di l’installazione
@@ -246,7 +247,7 @@ ApplicationsFound2=St’appiecazioni impieganu schedarii chì devenu esse mudifi
 CloseApplications=Chjode &autumaticamente l’appiecazioni
 DontCloseApplications=Ùn chjode &micca l’appiecazioni
 ErrorCloseApplications=L’assistente ùn hà micca pussutu chjode autumaticamente tutti l’appiecazioni. Nanzu di cuntinuà, hè ricumandatu di chjode tutti l’appiecazioni chì impieganu schedarii chì devenu esse mudificati da l’assistente durante l’installazione.
-PrepareToInstallNeedsRestart=L’assistente deve ridimarrà l’urdinatore. Dopu, ci vulerà à rilancià l’assistente per compie l’installazione di [name].%n%nVulete ridimarrà l’urdinatore subitu ?
+PrepareToInstallNeedsRestart=L’assistente deve ridimarrà l’urdinatore. Dopu, ci vulerà à rilancià l’assistente per compie l’installazione di [name].%n%nVulete ridimarrà l’urdinatore subitu ?
 
 ; *** "Installing" wizard page
 WizardInstalling=Installazione in corsu
@@ -257,8 +258,8 @@ FinishedHeadingLabel=Fine di l’installazione di [name]
 FinishedLabelNoIcons=L’assistente hà compiu l’installazione di [name] nant’à l’urdinatore.
 FinishedLabel=L’assistente hà compiu l’installazione di [name] nant’à l’urdinatore. L’appiecazione pò esse lanciata selezziunendu l’accurtatoghji installati.
 ClickFinish=Sceglie Piantà per compie l’assistente.
-FinishedRestartLabel=Per compie l’installazione di [name], l’assistente deve ridimarrà l’urdinatore. Vulete ridimarrà l’urdinatore subitu ?
-FinishedRestartMessage=Per compie l’installazione di [name], l’assistente deve ridimarrà l’urdinatore.%n%nVulete ridimarrà l’urdinatore subitu ?
+FinishedRestartLabel=Per compie l’installazione di [name], l’assistente deve ridimarrà l’urdinatore. Vulete ridimarrà l’urdinatore subitu ?
+FinishedRestartMessage=Per compie l’installazione di [name], l’assistente deve ridimarrà l’urdinatore.%n%nVulete ridimarrà l’urdinatore subitu ?
 ShowReadmeCheck=Iè, vogliu leghje u schedariu LISEZMOI o README
 YesRadio=&Iè, ridimarrà l’urdinatore subitu
 NoRadio=I&nnò, preferiscu ridimarrà l’urdinatore dopu
@@ -270,7 +271,7 @@ RunEntryShellExec=Fighjà %1
 ; *** "Setup Needs the Next Disk" stuff
 ChangeDiskTitle=L’assistente hà bisogniu di u discu seguente
 SelectDiskLabel2=Mette u discu %1 è sceglie Vai.%n%nS’è i schedarii di stu discu si trovanu in un’altru cartulare chì quellu indicatu inghjò, scrive u chjassu currettu o sceglie Sfuglià.
-PathLabel=&Chjassu :
+PathLabel=&Chjassu :
 FileNotInDir2=U schedariu « %1 » ùn si truva micca in « %2 ». Mette u discu curretu o sceglie un’altru cartulare.
 SelectDirectoryLabel=Ci vole à specificà induve si trova u discu seguente.
 
@@ -295,16 +296,16 @@ StatusRestartingApplications=Relanciu di l’appiecazioni…
 StatusRollback=Annulazione di i mudificazioni…
 
 ; *** Misc. errors
-ErrorInternal2=Sbagliu internu : %1
+ErrorInternal2=Sbagliu internu : %1
 ErrorFunctionFailedNoCode=Fiascu di %1
 ErrorFunctionFailed=Fiascu di %1 ; codice %2
 ErrorFunctionFailedWithMessage=Fiascu di %1 ; codice %2.%n%3
-ErrorExecutingProgram=Impussibule d’eseguisce u schedariu :%n%1
+ErrorExecutingProgram=Impussibule d’eseguisce u schedariu :%n%1
 
 ; *** Registry errors
-ErrorRegOpenKey=Sbagliu durante l’apertura di a chjave di registru :%n%1\%2
-ErrorRegCreateKey=Sbagliu durante a creazione di a chjave di registru :%n%1\%2
-ErrorRegWriteKey=Sbagliu durante a scrittura di a chjave di registru :%n%1\%2
+ErrorRegOpenKey=Sbagliu durante l’apertura di a chjave di registru :%n%1\%2
+ErrorRegCreateKey=Sbagliu durante a creazione di a chjave di registru :%n%1\%2
+ErrorRegWriteKey=Sbagliu durante a scrittura di a chjave di registru :%n%1\%2
 
 ; *** INI errors
 ErrorIniEntry=Sbagliu durante a creazione di l’elementu INI in u schedariu « %1 ».
@@ -317,7 +318,7 @@ SourceDoesntExist=U schedariu d’urigine « %1 » ùn esiste micca
 ExistingFileReadOnly2=U schedariu esistente hà un attributu di lettura-sola è ùn pò micca esse rimpiazzatu.
 ExistingFileReadOnlyRetry=&Caccià l’attributu di lettura-sola è pruvà torna
 ExistingFileReadOnlyKeepExisting=Cunservà u schedariu &esistente
-ErrorReadingExistingDest=Un sbagliu hè accadutu pruvendu di leghje u schedariu esistente :
+ErrorReadingExistingDest=Un sbagliu hè accadutu pruvendu di leghje u schedariu esistente :
 FileExistsSelectAction=Selezziunate un’azzione
 FileExists2=U schedariu esiste dighjà.
 FileExistsOverwriteExisting=&Rimpiazzà u schedariu chì esiste
@@ -328,16 +329,16 @@ ExistingFileNewer2=U schedariu esistente hè più recente chì quellu chì l’a
 ExistingFileNewerOverwriteExisting=&Rimpiazzà u schedariu chì esiste
 ExistingFileNewerKeepExisting=Cunservà u schedariu &esistente (ricumandatu)
 ExistingFileNewerOverwriteOrKeepAll=&Fà què per l’altri cunflitti
-ErrorChangingAttr=Un sbagliu hè accadutu pruvendu di cambià l’attributi di u schedariu esistente :
-ErrorCreatingTemp=Un sbagliu hè accadutu pruvendu di creà un schedariu in u cartulare di destinazione :
-ErrorReadingSource=Un sbagliu hè accadutu pruvendu di leghje u schedariu d’urigine :
-ErrorCopying=Un sbagliu hè accadutu pruvendu di cupià un schedariu :
-ErrorReplacingExistingFile=Un sbagliu hè accadutu pruvendu di rimpiazzà u schedariu esistente :
-ErrorRestartReplace=Fiascu di Rimpiazzamentu di schedariu à u riavviu di l’urdinatore :
-ErrorRenamingTemp=Un sbagliu hè accadutu pruvendu di rinumà un schedariu in u cartulare di destinazione :
-ErrorRegisterServer=Impussibule d’arregistrà a bibliuteca DLL/OCX : %1
+ErrorChangingAttr=Un sbagliu hè accadutu pruvendu di cambià l’attributi di u schedariu esistente :
+ErrorCreatingTemp=Un sbagliu hè accadutu pruvendu di creà un schedariu in u cartulare di destinazione :
+ErrorReadingSource=Un sbagliu hè accadutu pruvendu di leghje u schedariu d’urigine :
+ErrorCopying=Un sbagliu hè accadutu pruvendu di cupià un schedariu :
+ErrorReplacingExistingFile=Un sbagliu hè accadutu pruvendu di rimpiazzà u schedariu esistente :
+ErrorRestartReplace=Fiascu di Rimpiazzamentu di schedariu à u riavviu di l’urdinatore :
+ErrorRenamingTemp=Un sbagliu hè accadutu pruvendu di rinuminà un schedariu in u cartulare di destinazione :
+ErrorRegisterServer=Impussibule d’arregistrà a bibliuteca DLL/OCX : %1
 ErrorRegSvr32Failed=Fiascu di RegSvr32 cù codice d’esciuta %1
-ErrorRegisterTypeLib=Impussibule d’arregistrà a bibliuteca di tipu : %1
+ErrorRegisterTypeLib=Impussibule d’arregistrà a bibliuteca di tipu : %1
 
 ; *** Uninstall display name markings
 ; used for example as 'My Program (32-bit)'
@@ -358,20 +359,20 @@ UninstallNotFound=U schedariu « %1 » ùn esiste micca. Impussibule di disinsta
 UninstallOpenError=U schedariu« %1 » ùn pò micca esse apertu. Impussibule di disinstallà
 UninstallUnsupportedVer=U ghjurnale di disinstallazione « %1 » hè in una forma scunnisciuta da sta versione di l’assistente di disinstallazione. Impussibule di disinstallà
 UninstallUnknownEntry=Un elementu scunisciutu (%1) hè statu trovu in u ghjurnale di disinstallazione
-ConfirmUninstall=Site sicuru di vulè caccià cumpletamente %1 è tutti i so cumpunenti ?
+ConfirmUninstall=Site sicuru di vulè caccià cumpletamente %1 è tutti i so cumpunenti ?
 UninstallOnlyOnWin64=St’appiecazione pò esse disinstallata solu cù una versione 64-bit di Windows.
 OnlyAdminCanUninstall=St’appiecazione pò esse disinstallata solu da un utilizatore di u gruppu d’amministratori.
 UninstallStatusLabel=Ci vole à aspettà chì %1 sia cacciatu di l’urdinatore.
 UninstalledAll=%1 hè statu cacciatu bè da l’urdinatore.
 UninstalledMost=A disinstallazione di %1 hè compia.%n%nQualchì elementu ùn pò micca esse cacciatu. Ci vole à cacciallu manualmente.
-UninstalledAndNeedsRestart=Per compie a disinstallazione di %1, l’urdinatore deve esse ridimarratu.%n%nVulete ridimarrà l’urdinatore subitu ?
+UninstalledAndNeedsRestart=Per compie a disinstallazione di %1, l’urdinatore deve esse ridimarratu.%n%nVulete ridimarrà l’urdinatore subitu ?
 UninstallDataCorrupted=U schedariu « %1 » hè alteratu. Impussibule di disinstallà
 
 ; *** Uninstallation phase messages
-ConfirmDeleteSharedFileTitle=Caccià i schedarii sparti ?
-ConfirmDeleteSharedFile2=U sistema indicheghja chì u schedariu spartu ùn hè più impiegatu da nisunu prugramma. Vulete chì a disinstallazione cacci stu schedariu spartu ?%n%nS’è qualchì prugramma impiegheghja sempre stu schedariu è ch’ellu hè cacciatu, quellu prugramma ùn puderà funziunà currettamente. S’è ùn site micca sicuru, sceglie Innò. Lascià stu schedariu nant’à u sistema ùn pò micca pruduce danni.
-SharedFileNameLabel=Nome di schedariu :
-SharedFileLocationLabel=Lucalizazione :
+ConfirmDeleteSharedFileTitle=Caccià i schedarii sparti ?
+ConfirmDeleteSharedFile2=U sistema indicheghja chì u schedariu spartu ùn hè più impiegatu da nisunu prugramma. Vulete chì a disinstallazione cacci stu schedariu spartu ?%n%nS’è qualchì prugramma impiegheghja sempre stu schedariu è ch’ellu hè cacciatu, quellu prugramma ùn puderà funziunà currettamente. S’è ùn site micca sicuru, sceglie Innò. Lascià stu schedariu nant’à u sistema ùn pò micca pruduce danni.
+SharedFileNameLabel=Nome di schedariu :
+SharedFileLocationLabel=Lucalizazione :
 WizardUninstalling=Statu di disinstallazione
 StatusUninstalling=Disinstallazione di %1…
 
@@ -385,7 +386,7 @@ ShutdownBlockReasonUninstallingApp=Disinstallazione di %1.
 [CustomMessages]
 
 NameAndVersion=%1 versione %2
-AdditionalIcons=Accurtatoghji addizziunali :
+AdditionalIcons=Accurtatoghji addizziunali :
 CreateDesktopIcon=Creà un accurtatoghju nant’à u &scagnu
 CreateQuickLaunchIcon=Creà un accurtatoghju nant’à a barra di &lanciu prontu
 ProgramOnTheWeb=%1 nant’à u Web
@@ -393,6 +394,6 @@ UninstallProgram=Disinstallà %1
 LaunchProgram=Lancià %1
 AssocFileExtension=&Assucià %1 cù l’estensione di schedariu %2
 AssocingFileExtension=Associu di %1 cù l’estensione di schedariu %2…
-AutoStartProgramGroupDescription=Lanciu autumaticu :
+AutoStartProgramGroupDescription=Lanciu autumaticu :
 AutoStartProgram=Lanciu autumaticu di %1
-AddonHostProgramNotFound=Impussibule di truvà %1 in u cartulare selezziunatu.%n%nVulete cuntinuà l’installazione quantunque ?
+AddonHostProgramNotFound=Impussibule di truvà %1 in u cartulare selezziunatu.%n%nVulete cuntinuà l’installazione quantunque ?


### PR DESCRIPTION
Hello Martijn,

I just updated the Corsican translation file to make some changes, especially to add an unbreakable space before all question marks and semicolons to follow the locale ponctuation rules.

On the other hand, I'm not sure if there is (again) a problem with the encoding. When I edit my local file with Notepad++, the encoding is correct (UTF-8 BOM) but when I download the current `Corsican.isl` either from `jrsoftware/issrc/Files/Languages/` repository or the new version from my local `/issrc repository`, the encoding is only UTF-8. I even deleted my local `/issrc` repository and created a brand new branch `issrc_201114` but the problem still occurs.

Please can you check and tell me if you see a problem on your side? If yes, do you have some recommendations for updating?

Thanks,
Patriccollu.