### PR TITLE
Increase internal VersionStringSize of IsMsiProductInstalled

### DIFF
--- a/Projects/Msi.pas
+++ b/Projects/Msi.pas
@@ -65,7 +65,7 @@ begin
     Exit;
   end;
 
-  VersionStringSize := 16;
+  VersionStringSize := 24;
   SetLength(VersionString, VersionStringSize);
   ErrorCode := MsiGetProductInfoFunc(ProductCode, 'VersionString', PChar(VersionString), VersionStringSize);
   if ErrorCode = ERROR_MORE_DATA then begin


### PR DESCRIPTION
On Windows 10 the product Visual C++ 2008 SP1 (Security Update – MFC) returns "9.0.30729.6161" proving that the build version is included even though [documentation says only major, minor and patch version is included in MSI ProductVersion](https://docs.microsoft.com/en-us/windows/win32/msi/productversion).

Therefore I would not trust it to only have max of 255 in major and minor either and would recommend to increase the max string size to accomodate "65535.65535.65535.65535" which would be 20 digits + 3 dots + 1 null terminator = 24.