### PR TITLE
Correcting GetSHA256OfUnicodeString example

### DIFF
--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -1229,7 +1229,7 @@ end;
         <example><pre>var
   SHA256: String;
 begin
-  SHA256 := GetSHA256OfUnicodeString('Test');
+  SHA256 := GetSHA256OfUnicodeString('test');
   // SHA256 = 'fe520676b1a1d93dabab2319eea03674f3632eaeeb163d1e88244f5eb1de10eb'
 end;
 </pre></example>

--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -1229,8 +1229,8 @@ end;
         <example><pre>var
   SHA256: String;
 begin
-  SHA256 := GetSHA256OfUnicodeString('test');
-  // SHA256 = 'fe520676b1a1d93dabab2319eea03674f3632eaeeb163d1e88244f5eb1de10eb'
+  SHA256 := GetSHA256OfUnicodeString('Test');
+  // SHA256 = 'e6fa3ca87b1b641ab646d3b4933bba8d0970763f030b6578a60abdeae7366247'
 end;
 </pre></example>
       </function>


### PR DESCRIPTION
The hash shown in the example shows a hash of `test`, not `Test`.