### PR TITLE
Add a GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: build
+
+on:
+  push:
+
+jobs:
+  build:
+    # Only set the topic `has-issrc-build-env` if the secrets are available
+    if: contains(github.event.repository.topics, 'has-issrc-build-env')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: initialize build environment
+        env:
+          ISSRC_BUILD_ENV_ZIP_PASSWORD: ${{ secrets.ISSRC_BUILD_ENV_ZIP_PASSWORD }}
+          ISSRC_BUILD_ENV_ZIP_URL: ${{ secrets.ISSRC_BUILD_ENV_ZIP_URL }}
+        run: |
+          (New-Object Net.WebClient).DownloadFile($env:ISSRC_BUILD_ENV_ZIP_URL, "issrc-build-env.zip")
+          & "C:\\Program Files\\7-Zip\\7z.exe" x -oissrc-build-env -p"$env:ISSRC_BUILD_ENV_ZIP_PASSWORD" issrc-build-env.zip
+          if (!(Test-Path issrc-build-env\bin\dcc32.exe)) {
+            Write-Host "Failed to extract dcc32.exe"
+            Exit 1
+          }
+          Remove-Item issrc-build-env.zip
+          $DELPHIXEROOT = (Get-Item .\issrc-build-env).FullName
+          "DELPHIXEROOT=$DELPHIXEROOT" |  Out-File -NoNewLine -Encoding ascii -Append "$env:GITHUB_ENV"
+      - name: build ISHelpGen
+        run: |
+          cd ISHelp\ISHelpGen
+          # Using `Out-File` to avoid UTF-16LE-encoded .bat files
+          "set DELPHIXEROOT=$env:DELPHIXEROOT" | Out-File -NoNewline -Encoding ascii compilesettings.bat
+          .\compile.bat
+      - name: build issrc
+        run: |
+          "set DELPHIXEROOT=$env:DELPHIXEROOT" | Out-File -NoNewline -Encoding ascii compilesettings.bat
+          "set HHCEXE=%ProgramFiles(x86)%\HTML Help Workshop\hhc.exe" | Out-File -NoNewline -Encoding ascii ISHelp\compilesettings.bat
+          "set HHCEXE=%ProgramFiles(x86)%\HTML Help Workshop\hhc.exe" | Out-File -NoNewline -Encoding ascii Projects\ISPP\Help\compilesettings.bat
+          .\build.bat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,29 @@ jobs:
           "set HHCEXE=%ProgramFiles(x86)%\HTML Help Workshop\hhc.exe" | Out-File -NoNewline -Encoding ascii ISHelp\compilesettings.bat
           "set HHCEXE=%ProgramFiles(x86)%\HTML Help Workshop\hhc.exe" | Out-File -NoNewline -Encoding ascii Projects\ISPP\Help\compilesettings.bat
           .\build.bat
+      - name: copy license.txt into all artifacts
+        run: |
+          copy license.txt Files
+          copy license.txt Output
+          copy license.txt Projects/ISPP/Help/Staging
+          copy license.txt ISHelp/Staging
+      - name: upload Files
+        uses: actions/upload-artifact@v2
+        with:
+          name: Files
+          path: Files
+      - name: upload installer
+        uses: actions/upload-artifact@v2
+        with:
+          name: Output
+          path: Output
+      - name: upload ISPP/Help
+        uses: actions/upload-artifact@v2
+        with:
+          name: Help
+          path: Projects/ISPP/Help/Staging
+      - name: upload ISHelp
+        uses: actions/upload-artifact@v2
+        with:
+          name: ISHelp
+          path: ISHelp/Staging

--- a/ISHelp/ISHelpGen/ISHelpGen.dpr
+++ b/ISHelp/ISHelpGen/ISHelpGen.dpr
@@ -422,7 +422,7 @@ begin
         Result := Result + '<ol>' + ParseFormattedText(Node) + '</ol>';
       elP:
         begin
-          if Node.Attributes['margin'] = 'no' then
+          if Node.HasAttribute('margin') and (Node.Attributes['margin'] = 'no') then
             Result := Result + '<div>' + ParseFormattedText(Node) + '</div>'
           else
             Result := Result + '<p>' + ParseFormattedText(Node) + '</p>';
@@ -483,7 +483,7 @@ begin
       elUL:
         begin
           B := CurrentListIsCompact;
-          CurrentListIsCompact := (Node.Attributes['appearance'] = 'compact');
+          CurrentListIsCompact := (Node.HasAttribute('appearance') and (Node.Attributes['appearance'] = 'compact'));
           Result := Result + '<ul>' + ParseFormattedText(Node) + '</ul>';
           CurrentListIsCompact := B;
         end;
@@ -934,7 +934,7 @@ procedure Go;
       Doc.StripComments;
 
       Node := Doc.Root;
-      if Node.Attributes['version'] <> XMLFileVersion then
+      if Node.HasAttribute('version') and (Node.Attributes['version'] <> XMLFileVersion) then
         raise Exception.CreateFmt('Unrecognized file version "%s" (expected "%s")',
           [Node.Attributes['version'], XMLFileVersion]);
       Node := Node.FirstChild;

--- a/ISHelp/ISHelpGen/ISHelpGen.dpr
+++ b/ISHelp/ISHelpGen/ISHelpGen.dpr
@@ -209,10 +209,12 @@ end;
 procedure SaveStringToFile(const S, Filename: String);
 var
   F: TFileStream;
+  U: UTF8String;
 begin
   F := TFileStream.Create(Filename, fmCreate);
   try
-    F.WriteBuffer(S[1], Length(S));
+    U := UTF8String(S);
+    F.WriteBuffer(U[1], Length(U));
   finally
     F.Free;
   end;

--- a/ISHelp/ISHelpGen/XMLParse.pas
+++ b/ISHelp/ISHelpGen/XMLParse.pas
@@ -185,7 +185,9 @@ end;
 constructor TXMLDocument.Create;
 begin
   inherited Create;
-  FDoc := CreateOleObject('MSXML2.DOMDocument.4.0');
+  FDoc := CreateOleObject('MSXML2.DOMDocument.6.0');
+  FDoc.setProperty('ProhibitDTD', False);
+  FDoc.resolveExternals := True;
   FDoc.async := False;
   FDoc.preserveWhitespace := True;
 end;

--- a/ISHelp/ISHelpGen/compile.bat
+++ b/ISHelp/ISHelpGen/compile.bat
@@ -15,17 +15,29 @@ echo ishelp\compilesettings.bat is missing or incomplete. It needs to be created
 echo with the following lines, adjusted for your system:
 echo.
 echo   set DELPHI7ROOT=%%ProgramFiles%%\delphi 7                [Path to Delphi 7 (or later)]
+echo or
+echo   set DELPHIXEROOT=C:\Program Files\Embarcadero\RAD Studio\20.0 [Path to Delphi 10.3 Rio (or later)]
 goto failed2
 
 :compilesettingsfound
 set DELPHI7ROOT=
 call .\compilesettings.bat
+if not "%DELPHIXEROOT%"=="" goto compilewithdelphixe
 if "%DELPHI7ROOT%"=="" goto compilesettingserror
 
 rem -------------------------------------------------------------------------
 
 echo Compiling ISHelpGen.dpr:
 "%DELPHI7ROOT%\bin\dcc32.exe" -Q -B -H -W %1 -U"%DELPHI7ROOT%\lib" ISHelpGen.dpr
+if errorlevel 1 goto failed
+
+echo Success!
+exit /b 0
+
+:compilewithdelphixe
+set DELPHIXEDISABLEDWARNINGS=-W-SYMBOL_DEPRECATED -W-SYMBOL_PLATFORM -W-UNSAFE_CAST -W-EXPLICIT_STRING_CAST -W-EXPLICIT_STRING_CAST_LOSS -W-IMPLICIT_INTEGER_CAST_LOSS -W-IMPLICIT_CONVERSION_LOSS
+
+"%DELPHIXEROOT%\bin\dcc32.exe" --no-config -NSsystem;system.win;winapi -Q -B -H -W %DELPHIXEDISABLEDWARNINGS% %1 -U"%DELPHIXEROOT%\lib\win32\release" ISHelpGen.dpr
 if errorlevel 1 goto failed
 
 echo Success!

--- a/README.md
+++ b/README.md
@@ -231,6 +231,50 @@ Inno Setup-specific editing guidelines for the help files
   surround it by `<tt></tt>` so that it's displayed in the Courier New font. This is
   a convention used throughout the help file. Example: `<tt>MinVersion</tt>`
 
+Setting up Continuous Integration
+---------------------------------
+
+Delphi is not offered for download via a public link, and while there is a
+free-of-charge community version, its license terms forbid sharing it with others, or
+even let other developers (outside your direct teammates) use it. However, what _is_
+allowed is to copy the files (or a subset thereof) to another machine for the specific
+purpose of supporting unattended builds.
+
+Inno Setup's source code includes a GitHub workflow that performs such unattended
+builds upon `push` events, it requires some setting up, though.
+
+Note: The following instructions assume that you have a correctly-licensed version
+of Delphi installed into `C:\Program Files (x86(\Embarcadero\Studio\20.0`.
+
+To generate the (encrypted) `.zip` file containing the files needed to build
+Inno Setup, use [7-Zip](https://www.7-zip.org/):
+
+```
+cd C:\Program Files (x86)\Embarcadero\Studio\20.0
+"C:\Program Files\7-Zip\7z.exe" a -mx9 -mem=AES256 -p"<password>" ^
+	%USERPROFILE%\issrc-build-env.zip ^
+	bin\dcc32.exe bin\rlink32.dll bin\lnk*.dll ^
+	lib/win32/release/Sys*.dcu lib/win32/release/*.res ^
+	lib/win32/release/System.*.dcu lib/win32/release/System.Generics.*.dcu ^
+	lib/win32/release/System.Internal.*.dcu lib/win32/release/System.Net.*.dcu ^
+	lib/win32/release/System.Net.HttpClient.*.dcu lib/win32/release/System.Win.*.dcu ^
+	lib/win32/release/Vcl.*.dcu lib/win32/release/Vcl.Imaging.*.dcu ^
+	lib/win32/release/Winapi.*.dcu
+```
+
+Then, upload this somewhere public, e.g. by attaching it to a comment in a
+GitHub issue. After that, add this URL as a new repository
+[secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+(at https://github.com/YOUR-USER-NAME/issrc/settings/secrets/actions), under the name
+`ISSRC_BUILD_ENV_ZIP_URL`, and the password as `ISSRC_BUILD_ENV_ZIP_PASSWORD`.
+
+Finally, indicate that your fork of the repository has those secrets, by adding the
+topic `has-issrc-build-env` (click the gear icon next to the "About" label at
+https://github.com/YOUR-USER-NAME/issrc to add the topic).
+
+Once that's done, you're set! The next time you push a branch to your fork, the
+workflow will be triggered automatically.
+
 <!-- Link references -->
 [CONTRIBUTING.md]: <CONTRIBUTING.md>
 [Projects\Lzma2\Encoder]: <Projects/Lzma2/Encoder>


### PR DESCRIPTION
This PR adds a GitHub workflow. Unfortunately, there is no version of Delphi available for direct download for use in CI builds. We have two options here:

- use a self-hosted runner with Delphi installed
- copy a minimal subset of Delphi's files onto the runner when building

The latter is less cumbersome to maintain, but due to reasons, we need to add a secret password to the repository and a secret URL to download the minimal issrc build environment. This minimal build environment was created by running the build locally while [the Process Monitor was running](https://docs.microsoft.com/en-us/sysinternals/downloads/procmon), then extracting the list of `.exe`, `.dll` and `.dcu` files that were used according to Process Monitor (not the most robust, but at least it results in a `.zip` file that only weighs ~7.5MB as opposed to naively zipping up all the files into a gigantic 1.2GB `.zip` file).

This GitHub workflow opens the door for asking contributors to test out fixes comfortably, merely by pointing them to build artifacts (which this PR does not yet add, as it is intended to gently ask whether this is a direction the InnoSetup maintainer(s) want to go?).

See https://github.com/dscho/issrc/actions/runs/1739134972 for an example how a successful run would look like.