### PR TITLE
Improve high DPI support for the installer

### DIFF
--- a/Projects/Compil32.manifest.txt
+++ b/Projects/Compil32.manifest.txt
@@ -28,7 +28,7 @@
 <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
 </application>
 <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">

--- a/Projects/XPTheme.manifest
+++ b/Projects/XPTheme.manifest
@@ -27,7 +27,8 @@
 </trustInfo>
 <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
 </application>
 <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
By adding the dpiAwareness field to the manifest file.

As a drive-by, add the recommended fallback value "PerMonitor"
to the dpiAwareness field of the compiler's manifest file.
The dpiAwareness field allows multiple values.