### PR TITLE
Document how to set up code-signing in the CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       - name: build issrc
         run: |
           "set DELPHIXEROOT=$env:DELPHIXEROOT" | Out-File -NoNewline -Encoding ascii compilesettings.bat
+          "set DELPHIXEROOT=$env:DELPHIXEROOT" | Out-File -NoNewline -Encoding ascii ISHelp\ISHelpGen\compilesettings.bat
           "set HHCEXE=%ProgramFiles(x86)%\HTML Help Workshop\hhc.exe" | Out-File -NoNewline -Encoding ascii ISHelp\compilesettings.bat
           "set HHCEXE=%ProgramFiles(x86)%\HTML Help Workshop\hhc.exe" | Out-File -NoNewline -Encoding ascii Projects\ISPP\Help\compilesettings.bat
           .\build.bat

--- a/README.md
+++ b/README.md
@@ -264,6 +264,31 @@ https://github.com/YOUR-USER-NAME/issrc to add the topic).
 Once that's done, you're set! The next time you push a branch to your fork, the
 workflow will be triggered automatically.
 
+### Setting up code-signing with Continuous Integration
+
+InnoSetup's official releases ship with executable files that are
+[code-signed](https://en.wikipedia.org/wiki/Code_signing), to allow users to
+verify that these files come from a trusted source.
+
+If you have a code-signing certificate, you can use that in the Continuous
+Integration to produce artifacts that are code-signed, too, as long as the
+certificate does not require any local-only security factor such as a USB
+security key. To use the certificate, you first have to add the [repository
+secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
+`CODESIGN_P12`, using as value the base64-encoded file contents of the
+certificate's `.p12` file (obtain this value e.g. by running `base64 -w 0
+<my-certificate.p12`). Then, add the corresponding certificate password as
+repository secret named `CODESIGN_PASS`.
+
+Once these two repository secrets are set, the Continuous Integration will
+automatically pick them up and code-sign the generated executable files.
+
+Note: These repository secrets are only _used_ in the Continuous Integration,
+and will _not_ be included in the build artifacts. Meaning: You do not have to
+worry that the InnoSetup compiler that is produced by the Continuous
+Integration will automatically use your code-signing certificate
+_on its own_ to produce code-signed installers.
+
 <!-- Link references -->
 [CONTRIBUTING.md]: <CONTRIBUTING.md>
 [Projects\Lzma2\Encoder]: <Projects/Lzma2/Encoder>


### PR DESCRIPTION
I added support in 9572aae to code-sign build artifacts, but this support was undocumented, though. Let's address that.

While contributing this fix, I noticed that the CI definition was stale and needed to be updated to be able to run successfully again, so I also included this fix in this PR.