### PR TITLE
Added a function and repaired the logging for downloads

### DIFF
--- a/Projects/ScriptFunc.pas
+++ b/Projects/ScriptFunc.pas
@@ -129,7 +129,7 @@ const
 
   { Install }
 {$IFNDEF PS_NOINT64}
-  InstallTable: array [0..3] of AnsiString =
+  InstallTable: array [0..4] of AnsiString =
 {$ELSE}
   InstallTable: array [0..2] of AnsiString =
 {$ENDIF}
@@ -138,7 +138,8 @@ const
     'function ExtractTemporaryFiles(const Pattern: String): Integer;',
 {$IFNDEF PS_NOINT64}
     'function DownloadTemporaryFile(const Url, FileName, RequiredSHA256OfFile: String; const OnDownloadProgress: TOnDownloadProgress): Int64;',
-    'function DownloadTemporaryFileSize(const Url: String): Int64;'
+    'function DownloadTemporaryFileSize(const Url: String): Int64;',
+    'function DownloadTemporaryFileDate(const Url: String): String;'
 {$ENDIF}
   );
 

--- a/Projects/ScriptFunc_R.pas
+++ b/Projects/ScriptFunc_R.pas
@@ -813,7 +813,8 @@ begin
     Stack.SetInt64(PStart, DownloadTemporaryFile(Stack.GetString(PStart-1), Stack.GetString(PStart-2), Stack.GetString(PStart-3), OnDownloadProgress));
   end else if Proc.Name = 'DOWNLOADTEMPORARYFILESIZE' then begin
     Stack.SetInt64(PStart, DownloadTemporaryFileSize(Stack.GetString(PStart-1)));
-{$ENDIF}
+  end else if Proc.Name = 'DOWNLOADTEMPORARYFILEDATE' then begin
+    Stack.SetString(PStart, DownloadTemporaryFileDate(Stack.GetString(PStart-1)));{$ENDIF}
   end else
     Result := False;
 end;

--- a/Projects/Struct.pas
+++ b/Projects/Struct.pas
@@ -17,8 +17,8 @@ uses
 
 const
   SetupTitle = 'Inno Setup';
-  SetupVersion = '6.2.1';
-  SetupBinVersion = (6 shl 24) + (2 shl 16) + (1 shl 8) + 0;
+  SetupVersion = '6.2.2';
+  SetupBinVersion = (6 shl 24) + (2 shl 16) + (2 shl 8) + 0;
 
 type
   TSetupID = array[0..63] of AnsiChar;


### PR DESCRIPTION
Hi!

I've reported a problem with the logging of the download functions and I found out, the problem is within the code. 

description:
If one uses the user:password@url link for downloads with basic authentication, the full URL appears in the log, including the password.

I have therefore written a small helper function called StripURL, that removes passwords from URLs. Then I changed the two occurrences of the logging to use the StripURL function. In this way, passwords are shown in the log as ***.

While I was at changing the download functions I added a new DownloadTemporaryFileDate function. It's nearly the same as DownloadTemporaryFileSize but returns the last-modified string. I did not write the help for that, because it depends if this function is included. But the help is straightforward.

install.pas
  added TLS1.3
  added StripURL
  changed logging to use the StripURL
  added DownloadTemporaryFileDate
scriptfunc.pas
  added the new function
scriptfunc_r.pas
  added the new function