### PR TITLE
HKCU key not Import. A Bug?

### DIFF
--- a/Projects/Src/CompWizardRegistryHelper.pas
+++ b/Projects/Src/CompWizardRegistryHelper.pas
@@ -324,7 +324,7 @@ begin
                                             .Replace('{', '{{')
                                             .QuotedString('"');
 
-        var FilterKey := ((FPrivilegesRequired = prAdmin) and RequiresNotAdminInstallMode(Entry)) or
+        var FilterKey := (not (FPrivilegesRequired = prAdmin) and RequiresNotAdminInstallMode(Entry)) or
                          ((FPrivilegesRequired = prLowest) and RequiresAdminInstallMode(Entry));
 
         if not FilterKey then


### PR DESCRIPTION
**HKCU** registry key entries are not imported in any of the setup privilege directive (neither _admin_ nor _lowest_).
Users will think that the import from registry file feature does not work.

The comment ";SOME KEYS FILTERED DUE TO PRIVILEGESREQUIRED SETTINGS!" is confusing.
It's not clear what you need to do to add all the entries from the registry file. (Or have to do it manually?)

I haven't figured out your logic and just broke it for now, so that there is an option to import HKCU keys and also to draw your attention to a possible problem.

Please check again.
Best Regards!

