### PR TITLE
Fixing a function TNewLinkLabel.AdjustHeight

### DIFF
--- a/Components/BidiCtrls.pas
+++ b/Components/BidiCtrls.pas
@@ -139,7 +139,7 @@ end;
 function TNewLinkLabel.AdjustHeight: Integer;
 begin
   var OldHeight := Height;
-  var IdealHeight := SendMessage(Handle, LM_GETIDEALHEIGHT, 0, 0);
+  var IdealHeight := SendMessage(Handle, LM_GETIDEALSIZE, Width, 0);
   if IdealHeight <> 0 then
     Height := IdealHeight;
   Result := Height - OldHeight;


### PR DESCRIPTION
LM_GETIDEALSIZE message returns Height for a **given Width**.