### PR TITLE
Fix error when logging process output

### DIFF
--- a/Examples/PowerShell.iss
+++ b/Examples/PowerShell.iss
@@ -59,7 +59,11 @@ end;
 function ExecAndGetFirstLine(const Filename, Params, WorkingDir: String; var ResultCode: Integer): String;
 begin
   Line := '';
-  ExecAndLogOutput(Filename, Params, WorkingDir, SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode, @ExecAndGetFirstLineLog);
+  try
+    ExecAndLogOutput(Filename, Params, WorkingDir, SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode, @ExecAndGetFirstLineLog);
+  except
+    Log(GetExceptionMessage);
+  end;
   Result := Line;
 end;
 

--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -2874,10 +2874,13 @@ end;</pre></example>
         <description><p>Identical to <link topic="isxfunc_Exec">Exec</link> except:</p>
 <p>Console programs are always hidden and the ShowCmd parameter only affects GUI programs, so always using <tt>SW_SHOWNORMAL</tt> instead of <tt>SW_HIDE</tt> is recommended.</p>
 <p>If OnLog is set to <tt>nil</tt> then the output of the executed executable or batch file is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view.</p>
-<p>If OnLog is not set to <tt>nil</tt> then the output is sent to the specified function, line by line.</p></description>
+<p>If OnLog is not set to <tt>nil</tt> then the output is sent to the specified function, line by line.</p>
+<p>An exception will be raised if there was an error setting up output redirection.</p></description>
         <remarks><p>Parameter <tt>Wait</tt> must always be set to <tt>ewWaitUntilTerminated</tt> when calling this function.</p>
 <p>TOnLog is defined as:</p>
-<p><tt>TOnLog = procedure(const S: String; const Error, FirstLine: Boolean);</tt></p></remarks>
+<p><tt>TOnLog = procedure(const S: String; const Error, FirstLine: Boolean);</tt></p>
+<p>Parameter S is the output line when Error is False, otherwise an error message. FirstLine is True if this is the first line of output from the program, otherwise False.</p>
+<p>Error will be True if setting up output redirection or reading the output failed, or if the output size exceeded 10mb. There is no further output after an error.</p></remarks>
         <example><pre>var
   Line: String;
 
@@ -2893,7 +2896,11 @@ end;
 function ExecAndGetFirstLine(const Filename, Params, WorkingDir: String; var ResultCode: Integer): String;
 begin
   Line := '';
-  ExecAndLogOutput(Filename, Params, WorkingDir, SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode, @ExecAndGetFirstLineLog);
+  try
+    ExecAndLogOutput(Filename, Params, WorkingDir, SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode, @ExecAndGetFirstLineLog);
+  except
+    Log(GetExceptionMessage);
+  end;
   Result := Line;
 end;</pre></example>
         <seealso><p><link topic="isxfunc_Exec">Exec</link></p></seealso>

--- a/Projects/ISPP/IsppFuncs.pas
+++ b/Projects/ISPP/IsppFuncs.pas
@@ -676,9 +676,9 @@ begin
 
     if Log and Assigned(LogProc) and WaitUntilTerminated then begin
       OutputReader := TCreateProcessOutputReader.Create(LogProc, LogProcData);
-      OutputReader.UpdateStartupInfo(StartupInfo, InheritHandles);
-      if InheritHandles then
-        dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
+      OutputReader.UpdateStartupInfo(StartupInfo);
+      InheritHandles := True;
+      dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
     end;
 
     Result := CreateProcess(nil, PChar(CmdLine), nil, nil, InheritHandles,

--- a/Projects/Src/Compile.pas
+++ b/Projects/Src/Compile.pas
@@ -7389,12 +7389,9 @@ procedure TSetupCompiler.SignCommand(const AName, ACommand, AParams, AExeFilenam
 
     var OutputReader := TCreateProcessOutputReader.Create(SignCommandLog, NativeInt(Self));
     try
-      var InheritHandles: Boolean;
-      var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE;
-
-      OutputReader.UpdateStartupInfo(StartupInfo, InheritHandles);
-      if InheritHandles then
-        dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
+      var InheritHandles := True;
+      var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE or CREATE_NO_WINDOW;
+      OutputReader.UpdateStartupInfo(StartupInfo);
 
       if not CreateProcess(nil, PChar(AFormattedCommand), nil, nil, InheritHandles,
          dwCreationFlags, nil, PChar(CompilerDir), StartupInfo, ProcessInfo) then begin

--- a/Projects/Src/InstFunc.pas
+++ b/Projects/Src/InstFunc.pas
@@ -953,9 +953,9 @@ begin
 
     if Log and Assigned(LogProc) and (Wait = ewWaitUntilTerminated) then begin
       OutputReader := TCreateProcessOutputReader.Create(LogProc, LogProcData);
-      OutputReader.UpdateStartupInfo(StartupInfo, InheritHandles);
-      if InheritHandles then
-        dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
+      OutputReader.UpdateStartupInfo(StartupInfo);
+      InheritHandles := True;
+      dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
     end;
 
     Result := CreateProcessRedir(DisableFsRedir, nil, PChar(CmdLine), nil, nil,


### PR DESCRIPTION
Thank you for introducing the new process output logging features. I think they will be very useful.

However, I noticed that when logging errors from `TCreateProcessOutputReader` the Error param is always False and the FirstLine param is always True. I've fixed this and additionally added an `OutputReader` prefix to the error message so it is clearer in the IDE where the error originated.

I've also unset the `TCreateProcessOutputReader` instance if there was an error when setting up the redirection handles, because the Read method is a no-op in this situation.

I've also made the following changes for you to consider, regarding the handling of errors from the `ExecAndLogOutput` function when `OnLog` is set:

- If there is an error setting up the redirection handles, the program will not be run and the function will return False, with the last error in ResultCode.
- If there is an error reading the program output, the function will return False, with the last error in ResultCode.

(Note that if `OnLog` is not set the program will always run and the function will return True. Likewise when processing a Run/UnistallRun `logoutput` flag, or ISPP's `ExecAndGetFirstLine`).

The logic is that if a user supplies their own function to get the output, then they probably need it so not getting any at all, or only some of it, is an error. This is backed up by `cmd.exe` behaviour which will show an error and not run the command if it cannot set up redirection. For example, running the following as a non-admin:

```
cmd /c echo hello >C:\Windows\System32\output.text
```

returns _Access is denied._ with error code 1.

However, using `LogProcData` in `InstExec` to determine if this is a user-supplied TOnLog procedure could be brittle, considering the number of places it is called from.

