### PR TITLE
Proposing an ExecAndCaptureOutput function

### DIFF
--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -2875,7 +2875,7 @@ end;</pre></example>
         <description><p>Identical to <link topic="isxfunc_Exec">Exec</link> except:</p>
 <p>Program output from the stdout and stderr streams is captured. This is different from <link topic="isxfunc_ExecAndLogOutput">ExecAndLogOutput</link> which merges the streams.</p>
 <p>Console programs are always hidden and the ShowCmd parameter only affects GUI programs, so always using <tt>SW_SHOWNORMAL</tt> instead of <tt>SW_HIDE</tt> is recommended.</p>
-<p>An exception will be raised if there was an error setting up output redirection (which should be very rare). The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view.</p></description>
+<p>An exception will be raised if there was an error setting up output redirection (which should be very rare).</p></description>
         <remarks><p>Parameter <tt>Wait</tt> must always be set to <tt>ewWaitUntilTerminated</tt> when calling this function.</p>
 <p>TExecOutput is defined as:</p>
 <pre>
@@ -2918,7 +2918,7 @@ end;</pre></example>
 <p>TOnLog is defined as:</p>
 <p><tt>TOnLog = procedure(const S: String; const Error, FirstLine: Boolean);</tt></p>
 <p>Parameter S is the output line when Error is False, otherwise an error message. FirstLine is True if this is the first line of output from the program, otherwise False.</p>
-<p>Error will be True if setting up output redirection or reading the output failed, or if the output size exceeded 10mb. There is no further output after an error.</p></remarks>
+<p>Error will be True if reading the output failed (which should be very rare), or if the output size exceeded 10mb. There is no further output after an error.</p></remarks>
         <example><pre>var
   Line: String;
 

--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -1651,7 +1651,8 @@ begin
     // handle failure if necessary; ResultCode contains the error code
   end;
 end;</pre></example>
-        <seealso><p><link topic="isxfunc_ExecAndLogOutput">ExecAndLogOutput</link><br />
+        <seealso><p><link topic="isxfunc_ExecAndCaptureOutput">ExecAndCaptureOutput</link><br />
+<link topic="isxfunc_ExecAndLogOutput">ExecAndLogOutput</link><br />
 <link topic="isxfunc_ExecAsOriginalUser">ExecAsOriginalUser</link></p></seealso>
       </function>
       <function>
@@ -2868,6 +2869,43 @@ end;</pre></example>
         <description><p>Logs the specified string in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view.</p></description>
         <remarks><p>Calls to this function are ignored if logging is not enabled (via the <link topic="setupcmdline">/LOG</link> command line parameter or the <link topic="setup_setuplogging">SetupLogging</link> [Setup] section directive or the <link topic="setup_uninstalllogging">UninstallLogging</link> [Setup] section directive or debugging from the Compiler IDE).</p></remarks>
       </function>
+<function>
+        <name>ExecAndCaptureOutput</name>
+        <prototype>function ExecAndCaptureOutput(const Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ResultCode: Integer; var Output: TExecOutput): Boolean;</prototype>
+        <description><p>Identical to <link topic="isxfunc_Exec">Exec</link> except:</p>
+<p>Program output from the stdout and stderr streams is captured. This is different from <link topic="isxfunc_ExecAndLogOutput">ExecAndLogOutput</link> which merges the streams.</p>
+<p>Console programs are always hidden and the ShowCmd parameter only affects GUI programs, so always using <tt>SW_SHOWNORMAL</tt> instead of <tt>SW_HIDE</tt> is recommended.</p>
+<p>An exception will be raised if there was an error setting up output redirection (which should be very rare). The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view.</p></description>
+        <remarks><p>Parameter <tt>Wait</tt> must always be set to <tt>ewWaitUntilTerminated</tt> when calling this function.</p>
+<p>TExecOutput is defined as:</p>
+<pre>
+  TExecOutput = record
+    StdOut: TArrayOfString;
+    StdErr: TArrayOfString;
+    Error: Boolean;
+  end;
+</pre>
+<p>Error will be True if an exception was raised or if there was an error reading the output (which should be very rare) or if the total output size exceeded 10mb. The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view. There is no further output after an error.</p></remarks>
+        <example><pre>var
+  ResultCode: Integer;
+  Output: TExecOutput;
+
+begin
+  try
+    // Get the system configuration
+    Result := ExecAndCaptureOutput(ExpandConst('{cmd}', 'systeminfo', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode, Output);
+  except
+    Result := False
+    Log(GetExceptionMessage);
+  end;
+
+  if Result then begin
+    // Do something with Output.StdOut
+  end;
+end;</pre></example>
+        <seealso><p><link topic="isxfunc_Exec">Exec</link><br />
+<link topic="isxfunc_ExecAndLogOutput">ExecAndLogOutput</link></p></seealso>
+      </function>
       <function>
         <name>ExecAndLogOutput</name>
         <prototype>function ExecAndLogOutput(const Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ResultCode: Integer; const OnLog: TOnLog): Boolean;</prototype>
@@ -2903,7 +2941,8 @@ begin
   end;
   Result := Line;
 end;</pre></example>
-        <seealso><p><link topic="isxfunc_Exec">Exec</link></p></seealso>
+        <seealso><p><link topic="isxfunc_Exec">Exec</link><br />
+<link topic="isxfunc_ExecAndCaptureOutput">ExecAndCaptureOutput</link></p></seealso>
       </function>
     </subcategory>
   </category>

--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -2885,7 +2885,8 @@ end;</pre></example>
     Error: Boolean;
   end;
 </pre>
-<p>Error will be True if there was an error reading the output (which should be very rare) or if the total output size exceeded 10mb. The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view. There is no further output after an error.</p></remarks>
+<p>Error will be True if there was an error reading the output (which should be very rare) or if the output is too big. The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view. There is no further output after an error.</p>
+<p>Output is limited to a total size of 10 million bytes or a maximum of 1 million lines.</p></remarks>
         <example><pre>var
   ResultCode: Integer;
   Output: TExecOutput;
@@ -2918,7 +2919,8 @@ end;</pre></example>
 <p>TOnLog is defined as:</p>
 <p><tt>TOnLog = procedure(const S: String; const Error, FirstLine: Boolean);</tt></p>
 <p>Parameter S is the output line when Error is False, otherwise an error message. FirstLine is True if this is the first line of output from the program, otherwise False.</p>
-<p>Error will be True if reading the output failed (which should be very rare), or if the output size exceeded 10mb. There is no further output after an error.</p></remarks>
+<p>Error will be True if reading the output failed (which should be very rare), or if the output is too big. There is no further output after an error.</p>
+<p>Output is limited to a total size of 10 million bytes or a maximum of 1 million lines.</p></remarks>
         <example><pre>var
   Line: String;
 

--- a/ISHelp/isxfunc.xml
+++ b/ISHelp/isxfunc.xml
@@ -2885,7 +2885,7 @@ end;</pre></example>
     Error: Boolean;
   end;
 </pre>
-<p>Error will be True if an exception was raised or if there was an error reading the output (which should be very rare) or if the total output size exceeded 10mb. The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view. There is no further output after an error.</p></remarks>
+<p>Error will be True if there was an error reading the output (which should be very rare) or if the total output size exceeded 10mb. The error is logged in Setup's or Uninstall's log file and/or in the Compiler IDE's "Debug Output" view. There is no further output after an error.</p></remarks>
         <example><pre>var
   ResultCode: Integer;
   Output: TExecOutput;

--- a/Projects/ISPP/IsppFuncs.pas
+++ b/Projects/ISPP/IsppFuncs.pas
@@ -632,8 +632,8 @@ end;
 
 function Exec(const Filename, Params: String; WorkingDir: String;
   const WaitUntilTerminated: Boolean; const ShowCmd: Integer;
-  const Preprocessor: TPreprocessor; const Log: Boolean; const LogProc: TLogProc;
-  const LogProcData: NativeInt; var ResultCode: Integer): Boolean;
+  const Preprocessor: TPreprocessor; const OutputParams: TOutputParams;
+  var ResultCode: Integer): Boolean;
 var
   CmdLine: String;
   WorkingDirP: PChar;
@@ -674,8 +674,8 @@ begin
     var InheritHandles := False;
     var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE;
 
-    if Log and Assigned(LogProc) and WaitUntilTerminated then begin
-      OutputReader := TCreateProcessOutputReader.Create(LogProc, LogProcData);
+    if OutputParams.Enabled and WaitUntilTerminated then begin
+      OutputReader := TCreateProcessOutputReader.Create(OutputParams);
       OutputReader.UpdateStartupInfo(StartupInfo);
       InheritHandles := True;
       dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
@@ -750,9 +750,10 @@ begin
       if (GetCount > 3) and (Get(3).Typ <> evNull) then WaitUntilTerminated := Get(3).AsInt <> 0;
       if (GetCount > 4) and (Get(4).Typ <> evNull) then ShowCmd := Get(4).AsInt;
       var Preprocessor := TPreprocessor(Ext);
+      var OutputParams := TOutputParams.WithLogData(ExecLog, NativeInt(Preprocessor));
       var ResultCode: Integer;
       var Success := Exec(Get(0).AsStr, ParamsS, WorkingDir, WaitUntilTerminated,
-        ShowCmd, Preprocessor, True, ExecLog, NativeInt(Preprocessor), ResultCode);
+        ShowCmd, Preprocessor, OutputParams, ResultCode);
       if not WaitUntilTerminated then
         MakeBool(ResPtr^, Success)
       else
@@ -799,9 +800,10 @@ begin
       var Data: TExecAndGetFirstLineLogData;
       Data.Preprocessor := TPreprocessor(Ext);
       Data.Line := '';
+      var OutputParams := TOutputParams.WithLogData(ExecAndGetFirstLineLog, NativeInt(@Data));
       var ResultCode: Integer;
       var Success := Exec(Get(0).AsStr, ParamsS, WorkingDir, True,
-        SW_SHOWNORMAL, Data.Preprocessor, True, ExecAndGetFirstLineLog, NativeInt(@Data), ResultCode);
+        SW_SHOWNORMAL, Data.Preprocessor, OutputParams, ResultCode);
       if Success then
         MakeStr(ResPtr^, Data.Line)
       else begin

--- a/Projects/Src/CmnFunc2.pas
+++ b/Projects/Src/CmnFunc2.pas
@@ -1654,13 +1654,11 @@ begin
   var NulDevice := CreateFile('\\.\NUL', GENERIC_READ,
     FILE_SHARE_READ or FILE_SHARE_WRITE, @SecurityAttributes,
     OPEN_EXISTING, 0, 0);
-  if NulDevice = INVALID_HANDLE_VALUE then
-    { In case the NUL device is missing (which it inexplicably seems to
-      be for some users, per web search), don't treat it as a fatal
-      error. Just leave FStdInNulDevice at 0. It's not ideal, but the
-      child process likely won't even attempt to access stdin anyway. }
-    LogErrorFmt('Failed to open NUL device (%d). Will pass NULL handle for stdin.', [GetLastError])
-  else
+  { In case the NUL device is missing (which it inexplicably seems to
+    be for some users, per web search), don't treat it as a fatal
+    error. Just leave FStdInNulDevice at 0. It's not ideal, but the
+    child process likely won't even attempt to access stdin anyway. }
+  if NulDevice <> INVALID_HANDLE_VALUE then
     FStdInNulDevice := NulDevice;
 
   PipeCreate(FStdOutPipeRead, FStdOutPipeWrite, SecurityAttributes);

--- a/Projects/Src/CmnFunc2.pas
+++ b/Projects/Src/CmnFunc2.pas
@@ -1786,14 +1786,15 @@ begin
         SetLength(Buffer, TotalBytesHave+BytesRead);
 
         { Check for completed lines thanks to the new data }
-        var P := FindNewLine(Buffer, LastRead);
-        while P <> 0 do begin
+        while FTotalLinesRead < FMaxTotalLinesToRead do begin
+          var P := FindNewLine(Buffer, LastRead);
+          if P = 0 then
+            Break;
           LogLine(Copy(Buffer, 1, P-1));
           Inc(FTotalLinesRead);
           if (Buffer[P] = #13) and (P < Length(Buffer)) and (Buffer[P+1] = #10) then
             Inc(P);
           Delete(Buffer, 1, P);
-          P := FindNewLine(Buffer, LastRead);
         end;
 
         Inc(FTotalBytesRead, BytesRead);

--- a/Projects/Src/Compile.pas
+++ b/Projects/Src/Compile.pas
@@ -7367,10 +7367,6 @@ procedure TSetupCompiler.SignCommand(const AName, ACommand, AParams, AExeFilenam
 
   procedure InternalSignCommand(const AFormattedCommand: String;
     const Delay: Cardinal);
-  var
-    StartupInfo: TStartupInfo;
-    ProcessInfo: TProcessInformation;
-    LastError, ExitCode: DWORD;
   begin
     {Also see IsppFuncs' Exec }
 
@@ -7382,12 +7378,16 @@ procedure TSetupCompiler.SignCommand(const AName, ACommand, AParams, AExeFilenam
 
     LastSignCommandStartTick := GetTickCount;
 
+    var StartupInfo: TStartupInfo;
+    var ProcessInfo: TProcessInformation;
+    var LastError, ExitCode: DWORD;
     FillChar(StartupInfo, SizeOf(StartupInfo), 0);
     StartupInfo.cb := SizeOf(StartupInfo);
     StartupInfo.dwFlags := STARTF_USESHOWWINDOW;
     StartupInfo.wShowWindow := IfThen(RunMinimized, SW_SHOWMINNOACTIVE, SW_SHOWNORMAL);
 
-    var OutputReader := TCreateProcessOutputReader.Create(SignCommandLog, NativeInt(Self));
+    var OutputParams := TOutputParams.WithLogData(SignCommandLog, NativeInt(Self));
+    var OutputReader := TCreateProcessOutputReader.Create(OutputParams);
     try
       var InheritHandles := True;
       var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE or CREATE_NO_WINDOW;

--- a/Projects/Src/Compile.pas
+++ b/Projects/Src/Compile.pas
@@ -7386,8 +7386,7 @@ procedure TSetupCompiler.SignCommand(const AName, ACommand, AParams, AExeFilenam
     StartupInfo.dwFlags := STARTF_USESHOWWINDOW;
     StartupInfo.wShowWindow := IfThen(RunMinimized, SW_SHOWMINNOACTIVE, SW_SHOWNORMAL);
 
-    var OutputParams := TOutputParams.WithLogData(SignCommandLog, NativeInt(Self));
-    var OutputReader := TCreateProcessOutputReader.Create(OutputParams);
+    var OutputReader := TCreateProcessOutputReader.Create(SignCommandLog, NativeInt(Self));
     try
       var InheritHandles := True;
       var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE or CREATE_NO_WINDOW;

--- a/Projects/Src/InstFunc.pas
+++ b/Projects/Src/InstFunc.pas
@@ -90,7 +90,7 @@ procedure IncrementSharedCount(const RegView: TRegView; const Filename: String;
   const AlreadyExisted: Boolean);
 function InstExec(const DisableFsRedir: Boolean; const Filename, Params: String;
   WorkingDir: String; const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  const ProcessMessagesProc: TProcedure; const OutputReader: TCreateProcessOutputReader;
   var ResultCode: Integer): Boolean;
 function InstShellExec(const Verb, Filename, Params: String; WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
@@ -905,7 +905,7 @@ end;
 
 function InstExec(const DisableFsRedir: Boolean; const Filename, Params: String;
   WorkingDir: String; const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  const ProcessMessagesProc: TProcedure; const OutputReader: TCreateProcessOutputReader;
   var ResultCode: Integer): Boolean;
 var
   CmdLine: String;
@@ -946,35 +946,29 @@ begin
   if WorkingDir = '' then
     WorkingDir := GetSystemDir;
 
-  var OutputReader: TCreateProcessOutputReader := nil;
-  try
-    var InheritHandles := False;
-    var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE;
+  var InheritHandles := False;
+  var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE;
 
-    if OutputParams.Enabled and (Wait = ewWaitUntilTerminated) then begin
-      OutputReader := TCreateProcessOutputReader.Create(OutputParams);
-      OutputReader.UpdateStartupInfo(StartupInfo);
-      InheritHandles := True;
-      dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
-    end;
-
-    Result := CreateProcessRedir(DisableFsRedir, nil, PChar(CmdLine), nil, nil,
-      InheritHandles, dwCreationFlags, nil, PChar(WorkingDir),
-      StartupInfo, ProcessInfo);
-    if not Result then begin
-      ResultCode := GetLastError;
-      Exit;
-    end;
-
-    { Don't need the thread handle, so close it now }
-    CloseHandle(ProcessInfo.hThread);
-    if OutputReader <> nil then
-      OutputReader.NotifyCreateProcessDone;
-    HandleProcessWait(ProcessInfo.hProcess, Wait, ProcessMessagesProc,
-      OutputReader, ResultCode);
-  finally
-    OutputReader.Free;
+  if (OutputReader <> nil) and (Wait = ewWaitUntilTerminated) then begin
+    OutputReader.UpdateStartupInfo(StartupInfo);
+    InheritHandles := True;
+    dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;
   end;
+
+  Result := CreateProcessRedir(DisableFsRedir, nil, PChar(CmdLine), nil, nil,
+    InheritHandles, dwCreationFlags, nil, PChar(WorkingDir),
+    StartupInfo, ProcessInfo);
+  if not Result then begin
+    ResultCode := GetLastError;
+    Exit;
+  end;
+
+  { Don't need the thread handle, so close it now }
+  CloseHandle(ProcessInfo.hThread);
+  if OutputReader <> nil then
+    OutputReader.NotifyCreateProcessDone;
+  HandleProcessWait(ProcessInfo.hProcess, Wait, ProcessMessagesProc,
+    OutputReader, ResultCode);
 end;
 
 function InstShellExec(const Verb, Filename, Params: String; WorkingDir: String;

--- a/Projects/Src/InstFunc.pas
+++ b/Projects/Src/InstFunc.pas
@@ -90,8 +90,8 @@ procedure IncrementSharedCount(const RegView: TRegView; const Filename: String;
   const AlreadyExisted: Boolean);
 function InstExec(const DisableFsRedir: Boolean; const Filename, Params: String;
   WorkingDir: String; const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const Log: Boolean; const LogProc: TLogProc;
-  const LogProcData: NativeInt; var ResultCode: Integer): Boolean;
+  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  var ResultCode: Integer): Boolean;
 function InstShellExec(const Verb, Filename, Params: String; WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
   const ProcessMessagesProc: TProcedure; var ResultCode: Integer): Boolean;
@@ -905,8 +905,8 @@ end;
 
 function InstExec(const DisableFsRedir: Boolean; const Filename, Params: String;
   WorkingDir: String; const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const Log: Boolean; const LogProc: TLogProc;
-  const LogProcData: NativeInt; var ResultCode: Integer): Boolean;
+  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  var ResultCode: Integer): Boolean;
 var
   CmdLine: String;
   StartupInfo: TStartupInfo;
@@ -951,8 +951,8 @@ begin
     var InheritHandles := False;
     var dwCreationFlags: DWORD := CREATE_DEFAULT_ERROR_MODE;
 
-    if Log and Assigned(LogProc) and (Wait = ewWaitUntilTerminated) then begin
-      OutputReader := TCreateProcessOutputReader.Create(LogProc, LogProcData);
+    if OutputParams.Enabled and (Wait = ewWaitUntilTerminated) then begin
+      OutputReader := TCreateProcessOutputReader.Create(OutputParams);
       OutputReader.UpdateStartupInfo(StartupInfo);
       InheritHandles := True;
       dwCreationFlags := dwCreationFlags or CREATE_NO_WINDOW;

--- a/Projects/Src/Main.pas
+++ b/Projects/Src/Main.pas
@@ -3921,10 +3921,12 @@ begin
       DisableFsRedir := ShouldDisableFsRedirForRunEntry(RunEntry);
       if not(roSkipIfDoesntExist in RunEntry.Options) or
          NewFileExistsRedir(DisableFsRedir, ExpandedFilename) then begin
+        var OutputParams: TOutputParams;
+        if GetLogActive and (roLogOutput in RunEntry.Options) then
+          OutputParams.SetLogData(RunExecLog, 0);
         if not InstExecEx(RunAsOriginalUser, DisableFsRedir, ExpandedFilename,
            ExpandedParameters, ExpandConst(RunEntry.WorkingDir),
-           Wait, RunEntry.ShowCmd, ProcessMessagesProc, GetLogActive and (roLogOutput in RunEntry.Options),
-           RunExecLog, 0, ErrorCode) then
+           Wait, RunEntry.ShowCmd, ProcessMessagesProc, OutputParams, ErrorCode) then
           raise Exception.Create(FmtSetupMessage1(msgErrorExecutingProgram, ExpandedFilename) +
             SNewLine2 + FmtSetupMessage(msgErrorFunctionFailedWithMessage,
             ['CreateProcess', IntToStr(ErrorCode), Win32ErrorString(ErrorCode)]));

--- a/Projects/Src/Main.pas
+++ b/Projects/Src/Main.pas
@@ -3921,17 +3921,21 @@ begin
       DisableFsRedir := ShouldDisableFsRedirForRunEntry(RunEntry);
       if not(roSkipIfDoesntExist in RunEntry.Options) or
          NewFileExistsRedir(DisableFsRedir, ExpandedFilename) then begin
-        var OutputParams: TOutputParams;
-        if GetLogActive and (roLogOutput in RunEntry.Options) then
-          OutputParams.SetLogData(RunExecLog, 0);
-        if not InstExecEx(RunAsOriginalUser, DisableFsRedir, ExpandedFilename,
-           ExpandedParameters, ExpandConst(RunEntry.WorkingDir),
-           Wait, RunEntry.ShowCmd, ProcessMessagesProc, OutputParams, ErrorCode) then
-          raise Exception.Create(FmtSetupMessage1(msgErrorExecutingProgram, ExpandedFilename) +
-            SNewLine2 + FmtSetupMessage(msgErrorFunctionFailedWithMessage,
-            ['CreateProcess', IntToStr(ErrorCode), Win32ErrorString(ErrorCode)]));
-        if Wait = ewWaitUntilTerminated then
-          Log(Format('Process exit code: %u', [ErrorCode]));
+        var OutputReader: TCreateProcessOutputReader := nil;
+        try
+          if GetLogActive and (roLogOutput in RunEntry.Options) then
+            OutputReader := TCreateProcessOutputReader.Create(RunExecLog, 0);
+          if not InstExecEx(RunAsOriginalUser, DisableFsRedir, ExpandedFilename,
+             ExpandedParameters, ExpandConst(RunEntry.WorkingDir),
+             Wait, RunEntry.ShowCmd, ProcessMessagesProc, OutputReader, ErrorCode) then
+            raise Exception.Create(FmtSetupMessage1(msgErrorExecutingProgram, ExpandedFilename) +
+              SNewLine2 + FmtSetupMessage(msgErrorFunctionFailedWithMessage,
+              ['CreateProcess', IntToStr(ErrorCode), Win32ErrorString(ErrorCode)]));
+          if Wait = ewWaitUntilTerminated then
+            Log(Format('Process exit code: %u', [ErrorCode]));
+        finally
+          OutputReader.Free;
+        end;
       end
       else
         Log('File doesn''t exist. Skipping.');

--- a/Projects/Src/ScriptFunc.pas
+++ b/Projects/Src/ScriptFunc.pas
@@ -133,7 +133,7 @@ const
   );
 
   { InstFunc }
-  InstFuncTable: array [0..31] of AnsiString =
+  InstFuncTable: array [0..32] of AnsiString =
   (
     'function CheckForMutexes(Mutexes: String): Boolean;',
     'function DecrementSharedCount(const Is64Bit: Boolean; const Filename: String): Boolean;',
@@ -158,6 +158,7 @@ const
     //function GrantPermissionOnKey(const RootKey: HKEY; const Subkey: String; const Entries: TGrantPermissionEntry; const EntryCount: Integer): Boolean;
     'procedure IncrementSharedCount(const Is64Bit: Boolean; const Filename: String; const AlreadyExisted: Boolean);',
     'function Exec(const Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ResultCode: Integer): Boolean;',
+    'function ExecAndCaptureOutput(const Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ResultCode: Integer; var Output: TExecOutput): Boolean;',
     'function ExecAndLogOutput(const Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ResultCode: Integer; const OnLog: TOnLog): Boolean;',
     'function ExecAsOriginalUser(const Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ResultCode: Integer): Boolean;',
     'function ShellExec(const Verb, Filename, Params, WorkingDir: String; const ShowCmd: Integer; const Wait: TExecWait; var ErrorCode: Integer): Boolean;',

--- a/Projects/Src/ScriptFunc_C.pas
+++ b/Projects/Src/ScriptFunc_C.pas
@@ -116,7 +116,14 @@ begin
   RegisterRealEnum('TDotNetVersion', TypeInfo(TDotNetVersion));
 
   RegisterType('TExecWait', '(ewNoWait, ewWaitUntilTerminated, ewWaitUntilIdle)');
-  
+
+  RegisterType('TExecOutput',
+    'record' +
+    '  StdOut: TArrayOfString;' +
+    '  StdErr: TArrayOfString;' +
+    '  Error: Boolean;' +
+    'end');
+
   RegisterType('TFindRec',
     'record' +
     '  Name: String;' +

--- a/Projects/Src/ScriptFunc_R.pas
+++ b/Projects/Src/ScriptFunc_R.pas
@@ -806,12 +806,39 @@ begin
 end;
 
 type
+  { These must keep this in synch with ScriptFunc_C }
   TOnLog = procedure(const S: String; const Error, FirstLine: Boolean) of object;
+
+  TExecOutput = record
+    StdOut: PPSVariantIFC;
+    StdErr: PPSVariantIFC;
+    Error: Boolean;
+  end;
 
 procedure ExecAndLogOutputLogCustom(const S: String; const Error, FirstLine: Boolean; const Data: NativeInt);
 begin
   var OnLog := TOnLog(PMethod(Data)^);
   OnLog(S, Error, FirstLine);
+end;
+
+procedure ExecAndCaptureFinalize(StackData: Pointer; const OutputParams: TOutputParams);
+begin
+  var I: Integer;
+  { StdOut - 0 }
+  var Item := NewTPSVariantRecordIFC(StackData, 0);
+  PSDynArraySetLength(Pointer(Item.Dta^), Item.aType, OutputParams.OutList.Count);
+  for I := 0 to OutputParams.OutList.Count - 1 do
+    VNSetString(PSGetArrayField(Item, I), OutputParams.OutList[I]);
+
+  { StdErr - 1 }
+  Item := NewTPSVariantRecordIFC(StackData, 1);
+  PSDynArraySetLength(Pointer(Item.Dta^), Item.aType, OutputParams.ErrList.Count);
+  for I := 0 to OutputParams.ErrList.Count - 1 do
+    VNSetString(PSGetArrayField(Item, I), OutputParams.ErrList[I]);
+
+  { Error - 2 }
+  Item := NewTPSVariantRecordIFC(StackData, 2);
+  VNSetInt(Item, OutputParams.Error.ToInteger);
 end;
 
 function InstFuncProc(Caller: TPSExec; Proc: TPSExternalProcRec; Global, Stack: TPSStack): Boolean;
@@ -895,30 +922,27 @@ begin
     else
       IncrementSharedCount(rv32Bit, Stack.GetString(PStart-1), Stack.GetBool(PStart-2));
   end else if (Proc.Name = 'EXEC') or (Proc.Name = 'EXECASORIGINALUSER') or
-              (Proc.Name = 'EXECANDLOGOUTPUT') then begin
+              (Proc.Name = 'EXECANDLOGOUTPUT') or (Proc.Name = 'EXECANDCAPTUREOUTPUT') then begin
     var RunAsOriginalUser := Proc.Name = 'EXECASORIGINALUSER';
-    var LogOutput: Boolean;
-    var LogProc: TLogProc := nil;
-    var LogProcData: NativeInt := 0;
+    var OutputParams: TOutputParams;
     var Method: TMethod;
     if Proc.Name = 'EXECANDLOGOUTPUT' then begin
       var P: PPSVariantProcPtr := Stack.Items[PStart-7];
       { ProcNo 0 means nil was passed by the script }
       if P.ProcNo <> 0 then begin
-        LogOutput := True;
-        LogProc := ExecAndLogOutputLogCustom;
         Method := Caller.GetProcAsMethod(P.ProcNo); { This is a TOnLog }
-        LogProcData := NativeInt(@Method);
-      end else begin
-        LogOutput := GetLogActive;
-        LogProc := ExecAndLogOutputLog;
-      end;
-    end else
-      LogOutput := False;
+        OutputParams.SetLogData(ExecAndLogOutputLogCustom, NativeInt(@Method));
+      end else if GetLogActive then
+        OutputParams.SetLogData(ExecAndLogOutputLog, 0);
+    end else if Proc.Name = 'EXECANDCAPTUREOUTPUT' then begin
+      OutputParams.SetCaptureData(ExecAndLogOutputLog);
+      var Item := NewTPSVariantRecordIFC(Stack[PStart-7], 2);
+      VNSetInt(Item, 1);
+    end;
     var ExecWait := TExecWait(Stack.GetInt(PStart-5));
     if IsUninstaller and RunAsOriginalUser then
       NoUninstallFuncError(Proc.Name)
-    else if LogOutput and (ExecWait <> ewWaitUntilTerminated) then
+    else if OutputParams.Enabled and (ExecWait <> ewWaitUntilTerminated) then
       InternalError(Format('Must call "%s" function with Wait = ewWaitUntilTerminated', [Proc.Name]));
 
     Filename := Stack.GetString(PStart-1);
@@ -930,12 +954,13 @@ begin
         Stack.SetBool(PStart, InstExecEx(RunAsOriginalUser,
           ScriptFuncDisableFsRedir, Filename, Stack.GetString(PStart-2),
           Stack.GetString(PStart-3), ExecWait,
-          Stack.GetInt(PStart-4), ProcessMessagesProc, LogOutput,
-          LogProc, LogProcData, ResultCode));
+          Stack.GetInt(PStart-4), ProcessMessagesProc, OutputParams, ResultCode));
       finally
         WindowDisabler.Free;
       end;
       Stack.SetInt(PStart-6, ResultCode);
+      if Proc.Name = 'EXECANDCAPTUREOUTPUT' then
+        ExecAndCaptureFinalize(Stack[PStart-7], OutputParams);
     end else begin
       Stack.SetBool(PStart, False);
       Stack.SetInt(PStart-6, ERROR_ACCESS_DENIED);

--- a/Projects/Src/SpawnClient.pas
+++ b/Projects/Src/SpawnClient.pas
@@ -21,7 +21,7 @@ procedure InitializeSpawnClient(const AServerWnd: HWND);
 function InstExecEx(const RunAsOriginalUser: Boolean;
   const DisableFsRedir: Boolean; const Filename, Params, WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  const ProcessMessagesProc: TProcedure; const OutputReader: TCreateProcessOutputReader;
   var ResultCode: Integer): Boolean;
 function InstShellExecEx(const RunAsOriginalUser: Boolean;
   const Verb, Filename, Params, WorkingDir: String;
@@ -138,14 +138,14 @@ end;
 function InstExecEx(const RunAsOriginalUser: Boolean;
   const DisableFsRedir: Boolean; const Filename, Params, WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  const ProcessMessagesProc: TProcedure; const OutputReader: TCreateProcessOutputReader;
   var ResultCode: Integer): Boolean;
 var
   M: TMemoryStream;
 begin
   if not RunAsOriginalUser or not SpawnServerPresent then begin
     Result := InstExec(DisableFsRedir, Filename, Params, WorkingDir,
-      Wait, ShowCmd, ProcessMessagesProc, OutputParams, ResultCode);
+      Wait, ShowCmd, ProcessMessagesProc, OutputReader, ResultCode);
     Exit;
   end;
 

--- a/Projects/Src/SpawnClient.pas
+++ b/Projects/Src/SpawnClient.pas
@@ -21,8 +21,8 @@ procedure InitializeSpawnClient(const AServerWnd: HWND);
 function InstExecEx(const RunAsOriginalUser: Boolean;
   const DisableFsRedir: Boolean; const Filename, Params, WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const Log: Boolean; const LogProc: TLogProc;
-  const LogProcData: NativeInt; var ResultCode: Integer): Boolean;
+  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  var ResultCode: Integer): Boolean;
 function InstShellExecEx(const RunAsOriginalUser: Boolean;
   const Verb, Filename, Params, WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
@@ -138,14 +138,14 @@ end;
 function InstExecEx(const RunAsOriginalUser: Boolean;
   const DisableFsRedir: Boolean; const Filename, Params, WorkingDir: String;
   const Wait: TExecWait; const ShowCmd: Integer;
-  const ProcessMessagesProc: TProcedure; const Log: Boolean; const LogProc: TLogProc;
-  const LogProcData: NativeInt; var ResultCode: Integer): Boolean;
+  const ProcessMessagesProc: TProcedure; const OutputParams: TOutputParams;
+  var ResultCode: Integer): Boolean;
 var
   M: TMemoryStream;
 begin
   if not RunAsOriginalUser or not SpawnServerPresent then begin
     Result := InstExec(DisableFsRedir, Filename, Params, WorkingDir,
-      Wait, ShowCmd, ProcessMessagesProc, Log, LogProc, LogProcData, ResultCode);
+      Wait, ShowCmd, ProcessMessagesProc, OutputParams, ResultCode);
     Exit;
   end;
 

--- a/Projects/Src/SpawnServer.pas
+++ b/Projects/Src/SpawnServer.pas
@@ -379,9 +379,8 @@ begin
           TExecWait(EWait), EShowCmd, ProcessMessagesProc, FResultCode);
       end
       else begin
-        var OutputParams: TOutputParams;
         ExecResult := InstExec(EDisableFsRedir <> 0, EFilename, EParams, EWorkingDir,
-          TExecWait(EWait), EShowCmd, ProcessMessagesProc, OutputParams, FResultCode);
+          TExecWait(EWait), EShowCmd, ProcessMessagesProc, nil, FResultCode);
       end;
       if ExecResult then
         FCallStatus := SPAWN_STATUS_RETURNED_TRUE

--- a/Projects/Src/SpawnServer.pas
+++ b/Projects/Src/SpawnServer.pas
@@ -379,8 +379,9 @@ begin
           TExecWait(EWait), EShowCmd, ProcessMessagesProc, FResultCode);
       end
       else begin
+        var OutputParams: TOutputParams;
         ExecResult := InstExec(EDisableFsRedir <> 0, EFilename, EParams, EWorkingDir,
-          TExecWait(EWait), EShowCmd, ProcessMessagesProc, False, nil, 0, FResultCode);
+          TExecWait(EWait), EShowCmd, ProcessMessagesProc, OutputParams, FResultCode);
       end;
       if ExecResult then
         FCallStatus := SPAWN_STATUS_RETURNED_TRUE

--- a/Projects/Src/Undo.pas
+++ b/Projects/Src/Undo.pas
@@ -814,10 +814,12 @@ begin
                   Log('Running Exec parameters: ' + CurRecData[1]);
                 if (CurRec^.ExtraData and utRun_SkipIfDoesntExist = 0) or
                    NewFileExistsRedir(CurRec^.ExtraData and utRun_DisableFsRedir <> 0, CurRecData[0]) then begin
+                  var OutputParams: TOutputParams;
+                  if GetLogActive and (CurRec^.ExtraData and utRun_LogOutput <> 0) then
+                    OutputParams.SetLogData(RunExecLog, 0);
                   if not InstExec(CurRec^.ExtraData and utRun_DisableFsRedir <> 0,
                      CurRecData[0], CurRecData[1], CurRecData[2], Wait,
-                     ShowCmd, ProcessMessagesProc, GetLogActive and (CurRec^.ExtraData and utRun_LogOutput <> 0),
-                     RunExecLog, 0, ErrorCode) then begin
+                     ShowCmd, ProcessMessagesProc, OutputParams, ErrorCode) then begin
                     LogFmt('CreateProcess failed (%d).', [ErrorCode]);
                     Result := False;
                   end

--- a/Projects/Src/Undo.pas
+++ b/Projects/Src/Undo.pas
@@ -814,18 +814,22 @@ begin
                   Log('Running Exec parameters: ' + CurRecData[1]);
                 if (CurRec^.ExtraData and utRun_SkipIfDoesntExist = 0) or
                    NewFileExistsRedir(CurRec^.ExtraData and utRun_DisableFsRedir <> 0, CurRecData[0]) then begin
-                  var OutputParams: TOutputParams;
-                  if GetLogActive and (CurRec^.ExtraData and utRun_LogOutput <> 0) then
-                    OutputParams.SetLogData(RunExecLog, 0);
-                  if not InstExec(CurRec^.ExtraData and utRun_DisableFsRedir <> 0,
-                     CurRecData[0], CurRecData[1], CurRecData[2], Wait,
-                     ShowCmd, ProcessMessagesProc, OutputParams, ErrorCode) then begin
-                    LogFmt('CreateProcess failed (%d).', [ErrorCode]);
-                    Result := False;
-                  end
-                  else begin
-                    if Wait = ewWaitUntilTerminated then
-                      LogFmt('Process exit code: %u', [ErrorCode]);
+                  var OutputReader: TCreateProcessOutputReader := nil;
+                  try
+                    if GetLogActive and (CurRec^.ExtraData and utRun_LogOutput <> 0) then
+                      OutputReader := TCreateProcessOutputReader.Create(RunExecLog, 0);
+                    if not InstExec(CurRec^.ExtraData and utRun_DisableFsRedir <> 0,
+                       CurRecData[0], CurRecData[1], CurRecData[2], Wait,
+                       ShowCmd, ProcessMessagesProc, OutputReader, ErrorCode) then begin
+                      LogFmt('CreateProcess failed (%d).', [ErrorCode]);
+                      Result := False;
+                    end
+                    else begin
+                      if Wait = ewWaitUntilTerminated then
+                        LogFmt('Process exit code: %u', [ErrorCode]);
+                    end;
+                  finally
+                    OutputReader.Free;
                   end;
                 end else
                   Log('File doesn''t exist. Skipping.');

--- a/whatsnew.htm
+++ b/whatsnew.htm
@@ -68,6 +68,7 @@ For conditions of distribution and use, see <a href="files/is/license.txt">LICEN
   <li>Added new <i>Word Wrap</i> menu item to the <i>View</i> menu (Alt+Z).</li>
   <li>Added shortcut to the <i>Options</i> menu item in the <i>Tools</i> menu (Ctrl+,).</li>
   <li>Output logging now raises an exception if there was an error setting up output redirection (which should be very rare). The <i>PowerShell.iss</i> example script has been updated to catch the exception.</li>  
+  <li>Pascal Scripting change: Added new <tt>ExecAndCaptureOutput</tt> support function to execute a program or batch file and capture its <i>stdout</i> and <i>stderr</i> output.</li>
   <li>Various tweaks and documentation improvements.</li>
 </ul>
 


### PR DESCRIPTION
Following on from ExecAndLogOutput, this is a proposal for an `ExecAndCaptureOutput` function that captures program output from the stdout and stderr streams and writes it to a TExecOutput record.

```delphi
function ExecAndCaptureOutput(const Filename, Params, WorkingDir: String; const ShowCmd: Integer;
  const Wait: TExecWait; var ResultCode: Integer; var Output: TExecOutput): Boolean;
    
TExecOutput = record
  StdOut: TArrayOfString;
  StdErr: TArrayOfString;
end;
```
    
This is different from ExecAndLogOutput which merges the streams. The stderr stream is often used for non-error but informative output, so to split the streams you need to use Exec with cmd.exe to redirect to temporary files.  This new function does away with all that plumbing.

The PR is split into two commits. The first simplifies the exec logging parameters by wrapping them in a `TOutputParams` record, which lays the foundations for the second, which implements the new function.

The output is sent to files in the `_isetup` sub-directory of the temp folder. I don't know if this is a suitable location. The files are created with `CREATE_ALWAYS` in case en exception is raised before they are deleted.