### PR TITLE
Remove deprecated icons section flag 'foldershortcut'

### DIFF
--- a/Projects/Src/IDE.ScintStylerInnoSetup.pas
+++ b/Projects/Src/IDE.ScintStylerInnoSetup.pas
@@ -271,8 +271,8 @@ const
 
   IconsSectionFlags: array of TScintRawString = [
     'closeonexit', 'createonlyiffileexists', 'dontcloseonexit',
-    'excludefromshowinnewinstall', 'foldershortcut', 'preventpinning',
-    'runmaximized', 'runminimized', 'uninsneveruninstall', 'useapppaths'
+    'excludefromshowinnewinstall', 'preventpinning', 'runmaximized',
+    'runminimized', 'uninsneveruninstall', 'useapppaths'
   ];
 
   INISectionParameters: array of TScintRawString = [


### PR DESCRIPTION
`[Icons]` section flag `foldershortcut` was removed in 6.3.0 ([Rivision History](https://jrsoftware.org/files/is6.3-whatsnew.htm#:~:text=Removed%20%5BIcons%5D%20section%20flag%20foldershortcut%20which%20was%20already%20ignored%20except%20when%20running%20on%20Windows%20Vista%20or%20Windows%20Server%202008%2C%20as%20folder%20shortcuts%20do%20not%20expand%20properly%20on%20the%20Start%20Menu%20anymore.)),  but it is still shown in the compiler's autocomplete suggestions:

<img width="358" height="176" alt="image" src="https://github.com/user-attachments/assets/fc0c203f-0511-43d8-85ee-ec06a237d2b3" />

<br>
<br>

This pull request removes the flag from autocomplete to resolve the inconsistency between the compiler behavior (which rejects it) and the editor suggestions (which still show it).

It also prevents confusion that can lead to the compile error: `Parameter "Flags" includes an unknown flag.`