### PR TITLE
Avoid creating empty registry key when CLI is reading SignTools

### DIFF
--- a/Projects/Src/Shared.ConfigIniFile.pas
+++ b/Projects/Src/Shared.ConfigIniFile.pas
@@ -19,24 +19,40 @@ type
   private
     FMutex: THandle;
     FAcquiredMutex: Boolean;
+    procedure AcquireMutex;
   public
     constructor Create;
+    constructor CreateReadOnly;
     destructor Destroy; override;
   end;
 
 implementation
 
+const
+  ConfigRegKey = 'Software\Jordan Russell\Inno Setup';
+
 { TConfigIniFile }
 
-constructor TConfigIniFile.Create;
+procedure TConfigIniFile.AcquireMutex;
 begin
-  inherited Create('Software\Jordan Russell\Inno Setup');
   { Paranoia: Use a mutex to prevent multiple instances from reading/writing
     to the registry simultaneously }
   FMutex := CreateMutex(nil, False, 'Inno-Setup-IDE-Config-Mutex');
   if FMutex <> 0 then
     if WaitForSingleObject(FMutex, INFINITE) <> WAIT_FAILED then
       FAcquiredMutex := True;
+end;
+
+constructor TConfigIniFile.Create;
+begin
+  inherited Create(ConfigRegKey);
+  AcquireMutex;
+end;
+
+constructor TConfigIniFile.CreateReadOnly;
+begin
+  inherited Create(ConfigRegKey, KEY_READ);
+  AcquireMutex;
 end;
 
 destructor TConfigIniFile.Destroy;

--- a/Projects/Src/Shared.SignToolsFunc.pas
+++ b/Projects/Src/Shared.SignToolsFunc.pas
@@ -25,7 +25,7 @@ var
   I: Integer;
   S: String;
 begin
-  Ini := TConfigIniFile.Create;
+  Ini := TConfigIniFile.CreateReadOnly;
   try
     { Sign tools }
     SignTools.Clear();


### PR DESCRIPTION
Currently, running ISCC.exe creates an empty registry key `HKEY_CURRENT_USER\Software\Jordan Russell\Inno Setup` - if not already exists. I think this is unnecessary - in a stand-alone, portable install, where only the CLI is being used (e.g. in a CI workflow). This PR avoids it. The result makes the CLI more closer to what some refer to as a "stealth" or "portable app" tool.