### PR TITLE
Set dark scrollbar

### DIFF
--- a/ISHelp/Staging-dark/styles.css
+++ b/ISHelp/Staging-dark/styles.css
@@ -11,6 +11,14 @@ HTML {
 	/* Ensure that anchor targets don't get hidden underneath the sticky header.
 	   This is the height of .topicheading plus an extra 2rem of breathing room. */
 	scroll-padding-block-start: calc((20rem/16) * 1.5 + 8px + 2rem);
+	/* Set a dark color for the scrollbar in dark mode for the Help */
+	scrollbar-face-color: #606060;
+	scrollbar-shadow-color: #1f1f1f;
+	scrollbar-highlight-color: #a0a0a0;
+	scrollbar-3dlight-color: #1f1f1f;
+	scrollbar-darkshadow-color: #1f1f1f;
+	scrollbar-track-color: #1f1f1f;
+	scrollbar-arrow-color: #606060;
 }
 BODY {
 	font: calc(14rem/16)/1.5 "Segoe UI", sans-serif;


### PR DESCRIPTION
Set a dark color for the scrollbar in dark mode for the CHM Help.

In a CHM help file with a dark theme, the scrollbars use standard coloring:
<img width="750" height="443" alt="CHM-Dark_before" src="https://github.com/user-attachments/assets/783037b5-4d80-4667-9e3c-e6d92a518ac6" />

After applying the proposed patch, the scrollbar colors will match the dark theme:
<img width="750" height="443" alt="CHM-Dark_after" src="https://github.com/user-attachments/assets/b2c6779c-2e1d-4e41-a3e9-e76c3fbc6f47" />
