### PR TITLE
Review and update Serbian Latin translation for Inno Setup 6.5.0+

### DIFF
--- a/Files/Languages/Unofficial/SerbianLatin.isl
+++ b/Files/Languages/Unofficial/SerbianLatin.isl
@@ -5,6 +5,8 @@
 ;
 ; Maintained by Davor Nikolić (support@trackworktime.com).
 ; Based on previous translations of Rancher (theranchcowboy@gmail.com)
+; Reviewed and updated for Inno Setup 6.5.0+ by BlackSpirits
+; Last updated: 11 July 2026
 ;
 ; Note: When translating this text, do not add periods (.) to the end of
 ; messages that didn't have them already, because on those messages Inno
@@ -37,12 +39,12 @@ UninstallAppTitle=Deinstalacija
 UninstallAppFullTitle=Deinstalacija programa %1
 
 ; *** Misc. common
-InformationTitle=Podaci
+InformationTitle=Informacije
 ConfirmTitle=Potvrda
 ErrorTitle=Greška
 
 ; *** SetupLdr messages
-SetupLdrStartupMessage=Instaliraćete %1. Želite li da nastavite?
+SetupLdrStartupMessage=Ovim će se instalirati %1. Želite li da nastavite?
 LdrCannotCreateTemp=Ne mogu da napravim privremenu datoteku. Instalacija je prekinuta
 LdrCannotExecTemp=Ne mogu da pokrenem datoteku u privremenoj fascikli. Instalacija je prekinuta
 HelpTextNote=
@@ -51,24 +53,24 @@ HelpTextNote=
 LastErrorMessage=%1.%n%nGreška %2: %3
 SetupFileMissing=Datoteka %1 nedostaje u instalacionoj fascikli. Ispravite problem ili nabavite novi primerak programa.
 SetupFileCorrupt=Instalacione datoteke su oštećene. Nabavite novi primerak programa.
-SetupFileCorruptOrWrongVer=Instalacione datoteke su oštećene ili nisu saglasne s ovom verzijom instalacije. Ispravite problem ili nabavite novi primerak programa.
+SetupFileCorruptOrWrongVer=Instalacione datoteke su oštećene ili nisu kompatibilne s ovom verzijom instalacionog programa. Ispravite problem ili nabavite novi primerak programa.
 InvalidParameter=Neispravan parametar je prenet na komandnu liniju:%n%n%1
 SetupAlreadyRunning=Instalacija je već pokrenuta.
-WindowsVersionNotSupported=Program ne podržava izdanje Windows-a koje koristite.
-WindowsServicePackRequired=Program zahteva %1 servisni paket %2 ili noviji.
+WindowsVersionNotSupported=Ovaj program ne podržava verziju Windowsa koju računar koristi.
+WindowsServicePackRequired=Ovaj program zahteva %1 servisni paket %2 ili noviji.
 NotOnThisPlatform=Program neće raditi na %1.
-OnlyOnThisPlatform=Ovaj program može da radi samo na %1.
-OnlyOnTheseArchitectures=Program se može instalirati samo na izdanjima Windows-a koji rade na sledećim arhitekturama procesora:%n%n%1
-WinVersionTooLowError=Program zahteva %1, izdanje %2 ili novije.
-WinVersionTooHighError=Program ne možete instalirati na %1 izdanju %2 ili novijem.
+OnlyOnThisPlatform=Ovaj program mora da se pokrene na %1.
+OnlyOnTheseArchitectures=Ovaj program može da se instalira samo na verzijama Windowsa namenjenim sledećim arhitekturama procesora:%n%n%1
+WinVersionTooLowError=Ovaj program zahteva %1 verziju %2 ili noviju.
+WinVersionTooHighError=Ovaj program ne može da se instalira na %1 verziji %2 ili novijoj.
 AdminPrivilegesRequired=Morate biti prijavljeni kao administrator da biste instalirali program.
-PowerUserPrivilegesRequired=Morate biti prijavljeni kao administrator ili ovlašćeni korisnik da biste instalirali program.
-SetupAppRunningError=Program %1 je trenutno pokrenut.%n%nZatvorite ga i kliknite na dugme „U redu“ da nastavite ili „Otkaži“ da napustite instalaciju.
-UninstallAppRunningError=Program %1 je trenutno pokrenut.%n%nZatvorite ga i kliknite na dugme „U redu“ da nastavite ili „Otkaži“ da napustite instalaciju.
+PowerUserPrivilegesRequired=Morate biti prijavljeni kao administrator ili kao član grupe Power Users da biste instalirali ovaj program.
+SetupAppRunningError=Instalacioni program je otkrio da je %1 trenutno pokrenut.%n%nOdmah zatvorite sve njegove instance, zatim kliknite na „U redu“ da nastavite ili na „Otkaži“ da izađete.
+UninstallAppRunningError=Program za deinstalaciju je otkrio da je %1 trenutno pokrenut.%n%nOdmah zatvorite sve njegove instance, zatim kliknite na „U redu“ da nastavite ili na „Otkaži“ da izađete.
 
 ; *** Startup questions
-PrivilegesRequiredOverrideTitle=Odaberite način instalacije
-PrivilegesRequiredOverrideInstruction=Odaberite način instalacije
+PrivilegesRequiredOverrideTitle=Izaberite režim instalacije
+PrivilegesRequiredOverrideInstruction=Izaberite režim instalacije
 PrivilegesRequiredOverrideText1=%1 može biti instaliran za sve korisnike (zahteva administrativne privilegije) ili samo za vas.
 PrivilegesRequiredOverrideText2=%1 može da se instalira samo za vas ili za sve korisnike (zahteva administrativne privilegije).
 PrivilegesRequiredOverrideAllUsers=Instaliraj za &sve korisnike
@@ -77,15 +79,15 @@ PrivilegesRequiredOverrideCurrentUser=Instaliraj samo za &mene
 PrivilegesRequiredOverrideCurrentUserRecommended=Instaliraj samo za &mene (preporučeno)
 
 ; *** Misc. errors
-ErrorCreatingDir=Ne mogu da napravim fasciklu „%1“
+ErrorCreatingDir=Instalacioni program nije mogao da napravi fasciklu „%1“
 ErrorTooManyFilesInDir=Ne mogu da napravim datoteku u fascikli „%1“ jer sadrži previše datoteka
 
 ; *** Setup common messages
 ExitSetupTitle=Napuštanje instalacije
-ExitSetupMessage=Instalacija nije završena. Ako sada izađete, program neće biti instaliran.%n%nInstalaciju možete pokrenuti i dovršiti nekom drugom prilikom.%n%nŽelite li da je zatvorite?
-AboutSetupMenuItem=&O programu
-AboutSetupTitle=Podaci o programu
-AboutSetupMessage=%1 verzija %2%n%3%n%n%1 internet stranica:%n%4
+ExitSetupMessage=Instalacija nije završena. Ako sada izađete, program neće biti instaliran.%n%nInstalacioni program možete ponovo pokrenuti nekom drugom prilikom da biste dovršili instalaciju.%n%nŽelite li da izađete iz instalacionog programa?
+AboutSetupMenuItem=&O instalacionom programu...
+AboutSetupTitle=O instalacionom programu
+AboutSetupMessage=%1 verzija %2%n%3%n%nPočetna stranica programa %1:%n%4
 AboutSetupNote=
 TranslatorNote=
 
@@ -105,8 +107,8 @@ ButtonWizardBrowse=&Pretraži...
 ButtonNewFolder=&Napravi fasciklu
 
 ; *** "Select Language" dialog messages
-SelectLanguageTitle=Odabir jezika
-SelectLanguageLabel=Izaberite jezik za korišćenje tokom instalacije:
+SelectLanguageTitle=Izbor jezika instalacionog programa
+SelectLanguageLabel=Izaberite jezik koji će se koristiti tokom instalacije.
 
 ; *** Common wizard text
 ClickNext=Kliknite na „Dalje“ da nastavite ili „Otkaži“ da napustite instalaciju.
@@ -116,7 +118,7 @@ BrowseDialogLabel=Izaberite fasciklu sa spiska i kliknite na „U redu“.
 NewFolderName=Nova fascikla
 
 ; *** "Welcome" wizard page
-WelcomeLabel1=Dobro došli na instalaciju programa [name]
+WelcomeLabel1=Dobro došli u čarobnjak za instalaciju programa [name]
 WelcomeLabel2=Instaliraćete [name/ver] na računar.%n%nPre nego što nastavite, preporučujemo vam da zatvorite sve druge programe.
 
 ; *** "Password" wizard page
@@ -129,7 +131,7 @@ IncorrectPassword=Navedena lozinka nije ispravna. Pokušajte ponovo.
 ; *** "License Agreement" wizard
 WizardLicense=Ugovor o licenci
 LicenseLabel=Pažljivo pročitajte sledeće pre nego što nastavite.
-LicenseLabel3=Pročitajte Ugovor o licenci koji se nalazi ispod. Morate prihvatiti uslove ovog ugovora pre nego što nastavite.
+LicenseLabel3=Pročitajte sledeći Ugovor o licenci. Morate prihvatiti uslove ovog ugovora pre nego što nastavite s instalacijom.
 LicenseAccepted=&Prihvatam ugovor
 LicenseNotAccepted=&Ne prihvatam ugovor
 
@@ -151,20 +153,20 @@ UserInfoNameRequired=Morate navesti ime.
 
 ; *** "Select Destination Location" wizard page
 WizardSelectDir=Odabir odredišne fascikle
-SelectDirDesc=Izaberite mesto na kom želite da instalirate [name].
-SelectDirLabel3=Program će instalirati [name] u sledeću fasciklu.
+SelectDirDesc=Gde želite da se instalira [name]?
+SelectDirLabel3=Instalacioni program će instalirati [name] u sledeću fasciklu.
 SelectDirBrowseLabel=Kliknite na „Dalje“ da nastavite. Ako želite da izaberete drugu fasciklu, kliknite na „Pretraži...“.
 DiskSpaceGBLabel=Potrebno je najmanje [gb] GB slobodnog prostora na disku.
 DiskSpaceMBLabel=Potrebno je najmanje [mb] MB slobodnog prostora na disku.
 CannotInstallToNetworkDrive=Ne mogu da instaliram na mrežnu jedinicu.
 CannotInstallToUNCPath=Ne mogu da instaliram na UNC putanju.
-InvalidPath=Morate navesti punu putanju s obeležjem diska (npr.%n%nC:\APP%n%nili putanja u obliku%n%n\\server\share)
-InvalidDrive=Disk koji ste izabrali ne postoji ili nije dostupan. Izaberite neki drugi.
+InvalidPath=Morate uneti punu putanju sa slovom disk jedinice; na primer:%n%nC:\APP%n%nili UNC putanju u obliku:%n%n\\server\share
+InvalidDrive=Disk jedinica ili UNC deljenje koje ste izabrali ne postoji ili nije dostupno. Izaberite drugo.
 DiskSpaceWarningTitle=Nedovoljno prostora na disku
 DiskSpaceWarning=Program zahteva najmanje %1 kB slobodnog prostora, a izabrani disk na raspolaganju ima samo %2 kB.%n%nŽelite li ipak da nastavite?
 DirNameTooLong=Naziv fascikle ili putanja je predugačka.
 InvalidDirName=Naziv fascikle nije ispravan.
-BadDirName32=Naziv fascikle ne sme sadržati ništa od sledećeg:%n%n%1
+BadDirName32=Naziv fascikle ne sme da sadrži nijedan od sledećih znakova:%n%n%1
 DirExistsTitle=Fascikla već postoji
 DirExists=Fascikla:%n%n%1%n%nveć postoji. Želite li ipak da instalirate program u nju?
 DirDoesntExistTitle=Fascikla ne postoji
@@ -176,10 +178,10 @@ SelectComponentsDesc=Koje komponente želite da instalirate?
 SelectComponentsLabel2=Izaberite komponente koje želite da instalirate, a očistite one koje ne želite. Kliknite na „Dalje“ da nastavite.
 FullInstallation=Puna instalacija
 ; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
-CompactInstallation=Podrazumevana instalacija
+CompactInstallation=Kompaktna instalacija
 CustomInstallation=Prilagođena instalacija
 NoUninstallWarningTitle=Komponente već postoje
-NoUninstallWarning=Sledeće komponente već postoje na računaru:%n%n%1%n%nPoništavanje izbora ovih komponenti ih neće ukloniti.%n%nŽelite li da nastavite?
+NoUninstallWarning=Instalacioni program je otkrio da su sledeće komponente već instalirane na računaru:%n%n%1%n%nPoništavanje izbora ovih komponenti neće ih deinstalirati.%n%nŽelite li ipak da nastavite?
 ComponentSize1=%1 kB
 ComponentSize2=%1 MB
 ComponentsDiskSpaceGBLabel=Izabrane stavke zahtevaju najmanje [gb] GB slobodnog prostora.
@@ -187,13 +189,13 @@ ComponentsDiskSpaceMBLabel=Izabrane stavke zahtevaju najmanje [mb] MB slobodnog 
 
 ; *** "Select Additional Tasks" wizard page
 WizardSelectTasks=Odabir dodatnih zadataka
-SelectTasksDesc=Izaberite neke dodatne zadatke.
-SelectTasksLabel2=Izaberite dodatne zadatke koje želite da izvršite pri instaliranju programa [name] i kliknite na „Dalje“.
+SelectTasksDesc=Koje dodatne zadatke treba izvršiti?
+SelectTasksLabel2=Izaberite dodatne zadatke koje želite da instalacioni program izvrši tokom instalacije programa [name], zatim kliknite na „Dalje“.
 
 ; *** "Select Start Menu Folder" wizard page
 WizardSelectProgramGroup=Odabir fascikle u meniju „Start“
-SelectStartMenuFolderDesc=Izaberite mesto na kom želite da postavite prečice.
-SelectStartMenuFolderLabel3=Instalacija će postaviti prečice programa u sledećoj fascikli u meniju „Start“.
+SelectStartMenuFolderDesc=Gde instalacioni program treba da postavi prečice programa?
+SelectStartMenuFolderLabel3=Instalacioni program će napraviti prečice programa u sledećoj fascikli menija „Start“.
 SelectStartMenuFolderBrowseLabel=Kliknite na „Dalje“ da nastavite. Ako želite da izaberete drugu fasciklu, kliknite na „Pretraži...“.
 MustEnterGroupName=Morate navesti naziv fascikle.
 GroupNameTooLong=Naziv fascikle ili putanja je predugačka.
@@ -202,8 +204,8 @@ BadGroupName=Naziv fascikle ne sme sadržati ništa od sledećeg:%n%n%1
 NoProgramGroupCheck2=N&e pravi fasciklu u meniju „Start“
 
 ; *** "Ready to Install" wizard page
-WizardReady=Instalacija je spremna
-ReadyLabel1=Program je spreman da instalira [name] na računar.
+WizardReady=Spremno za instalaciju
+ReadyLabel1=Instalacioni program je spreman da započne instaliranje programa [name] na računar.
 ReadyLabel2a=Kliknite na „Instaliraj“ da započnete instalaciju ili „Nazad“ da ponovo pregledate i promenite pojedine postavke.
 ReadyLabel2b=Kliknite na „Instaliraj“ da započnete instalaciju.
 ReadyMemoUserInfo=Korisnički podaci:
@@ -227,7 +229,7 @@ ErrorFileSize=Neispravna veličina datoteke: očekivan %1, pronađen %2
 ExtractingLabel=Raspakivanje datoteka...
 ButtonStopExtraction=&Zaustavi raspakivanje
 StopExtraction=Da li ste sigurni da želite da zaustavite raspakivanje?
-ErrorExtractionAborted=Raspakivanje prekinuto
+ErrorExtractionAborted=Raspakivanje je prekinuto
 ErrorExtractionFailed=Raspakivanje nije uspelo: %1
 
 ; *** Archive extraction failure details
@@ -237,41 +239,41 @@ ArchiveUnsupportedFormat=Format arhive nije podržan
 
 ; *** "Preparing to Install" wizard page
 WizardPreparing=Priprema za instalaciju
-PreparingDesc=Program se priprema da instalira [name] na računar.
-PreviousInstallNotCompleted=Instalacija ili deinstalacija prethodnog programa nije završena. Potrebno je da ponovo pokrenete računar da bi se instalacija završila.%n%nNakon ponovnog pokretanja, otvorite instalaciju i instalirajte program [name].
-CannotContinue=Ne mogu da nastavim instalaciju. Kliknite na „Otkaži“ da izađete.
-ApplicationsFound=Sledeći programi koriste datoteke koje treba da ažurira instalacioni program. Preporučujemo vam da dozvolite instalacionom programu da zatvori ove programe.
-ApplicationsFound2=Sledeći programi koriste datoteke koje treba da ažurira instalacioni program. Preporučujemo vam da dozvolite instalacionom programu da zatvori ove programe. Nakon što se instalacija završi, instalacioni program će pokušati da ponovo pokrene zatvorene programe.
-CloseApplications=&Zatvori programe
-DontCloseApplications=&Ne zatvaraj programe
-ErrorCloseApplications=Ne mogu da zatvorim sve programe. Pre nego što nastavite, preporučujemo vam da zatvorite sve programe koji koriste datoteke koje treba da ažurira instalacioni program.
-PrepareToInstallNeedsRestart=Instalacija mora da ponovo pokrene računar. Nakon ponovnog pokretanja računara, ponovo pokrenite instalaciju da biste dovršili instalaciju [name].%n%nŽelite li da ponovo pokrenete računar sada?
+PreparingDesc=Instalacioni program se priprema da instalira [name] na računar.
+PreviousInstallNotCompleted=Instalacija ili uklanjanje prethodnog programa nije završeno. Morate ponovo pokrenuti računar da biste dovršili tu instalaciju.%n%nNakon ponovnog pokretanja računara ponovo pokrenite instalacioni program da biste dovršili instalaciju programa [name].
+CannotContinue=Instalacioni program ne može da nastavi. Kliknite na „Otkaži“ da izađete.
+ApplicationsFound=Sledeće aplikacije koriste datoteke koje instalacioni program treba da ažurira. Preporučuje se da dozvolite instalacionom programu da automatski zatvori ove aplikacije.
+ApplicationsFound2=Sledeće aplikacije koriste datoteke koje instalacioni program treba da ažurira. Preporučuje se da dozvolite instalacionom programu da automatski zatvori ove aplikacije. Kada se instalacija završi, instalacioni program će pokušati da ponovo pokrene aplikacije.
+CloseApplications=&Automatski zatvori aplikacije
+DontCloseApplications=&Ne zatvaraj aplikacije
+ErrorCloseApplications=Instalacioni program nije mogao automatski da zatvori sve aplikacije. Preporučuje se da pre nastavka zatvorite sve aplikacije koje koriste datoteke koje instalacioni program treba da ažurira.
+PrepareToInstallNeedsRestart=Instalacioni program mora ponovo da pokrene računar. Nakon ponovnog pokretanja računara ponovo pokrenite instalacioni program da biste dovršili instalaciju programa [name].%n%nŽelite li sada da ponovo pokrenete računar?
 
 ; *** "Installing" wizard page
 WizardInstalling=Instaliranje
-InstallingLabel=Sačekajte da se [name] instalira na računar.
+InstallingLabel=Sačekajte dok instalacioni program instalira [name] na računar.
 
 ; *** "Setup Completed" wizard page
-FinishedHeadingLabel=[name] – završetak instalacije
-FinishedLabelNoIcons=Instaliranje programa [name] je završeno.
-FinishedLabel=Instaliranje programa [name] je završeno. Možete ga pokrenuti preko postavljenih ikona.
-ClickFinish=Kliknite na „Završi“ da izađete.
-FinishedRestartLabel=Da bi se završila instalacija programa [name], potrebno je ponovo pokrenuti računar. Želite li da ga ponovo pokrenete?
-FinishedRestartMessage=Da bi se završila instalacija programa [name], potrebno je ponovo pokrenuti računar.%n%nŽelite li da ga ponovo pokrenete?
-ShowReadmeCheck=Da, želim da pogledam tekstualnu datoteku
+FinishedHeadingLabel=Dovršavanje čarobnjaka za instalaciju programa [name]
+FinishedLabelNoIcons=Instalacioni program je završio instaliranje programa [name] na računar.
+FinishedLabel=Instalacioni program je završio instaliranje programa [name] na računar. Aplikaciju možete pokrenuti izborom instaliranih prečica.
+ClickFinish=Kliknite na „Završi“ da izađete iz instalacionog programa.
+FinishedRestartLabel=Da bi se dovršila instalacija programa [name], instalacioni program mora ponovo da pokrene računar. Želite li sada da ga ponovo pokrenete?
+FinishedRestartMessage=Da bi se dovršila instalacija programa [name], instalacioni program mora ponovo da pokrene računar.%n%nŽelite li sada da ga ponovo pokrenete?
+ShowReadmeCheck=Da, želim da pogledam datoteku README
 YesRadio=&Da, ponovo pokreni računar
-NoRadio=&Ne, kasnije ću ga pokrenuti
+NoRadio=&Ne, ponovo ću pokrenuti računar kasnije
 ; used for example as 'Run MyProg.exe'
 RunEntryExec=Pokreni %1
 ; used for example as 'View Readme.txt'
 RunEntryShellExec=Pogledaj %1
 
 ; *** "Setup Needs the Next Disk" stuff
-ChangeDiskTitle=Sledeći disk
+ChangeDiskTitle=Instalacionom programu je potreban sledeći disk
 SelectDiskLabel2=Ubacite disk %1 i kliknite na „U redu“.%n%nAko se datoteke na ovom disku mogu pronaći u nekoj drugoj fascikli, unesite odgovarajuću putanju ili kliknite na „Pretraži...“.
 PathLabel=&Putanja:
 FileNotInDir2=Datoteka „%1“ se ne nalazi u „%2“. Ubacite pravi disk ili izaberite drugu fasciklu.
-SelectDirectoryLabel=Izaberite mesto sledećeg diska.
+SelectDirectoryLabel=Navedite lokaciju sledećeg diska.
 
 ; *** Installation phase messages
 SetupAborted=Instalacija nije završena.%n%nIspravite problem i pokrenite je ponovo.
@@ -284,24 +286,24 @@ RetryCancelRetry=&Pokušaj ponovo
 RetryCancelCancel=Otkaži
 
 ; *** Installation status messages
-StatusClosingApplications=Zatvaram programe...
-StatusCreateDirs=Pravim fascikle...
+StatusClosingApplications=Zatvaranje aplikacija...
+StatusCreateDirs=Pravljenje fascikli...
 StatusExtractFiles=Raspakivanje datoteka...
 StatusDownloadFiles=Preuzimanje datoteka...
-StatusCreateIcons=Postavljam prečice...
-StatusCreateIniEntries=Postavljam INI unose...
-StatusCreateRegistryEntries=Postavljam unose u registar...
-StatusRegisterFiles=Upisujem datoteke...
-StatusSavingUninstall=Čuvam podatke o deinstalaciji...
-StatusRunProgram=Završavam instalaciju...
-StatusRestartingApplications=Ponovo pokrećem programe...
-StatusRollback=Poništavam izmene...
+StatusCreateIcons=Pravljenje prečica...
+StatusCreateIniEntries=Pravljenje INI unosa...
+StatusCreateRegistryEntries=Pravljenje unosa u registru...
+StatusRegisterFiles=Registrovanje datoteka...
+StatusSavingUninstall=Čuvanje podataka za deinstalaciju...
+StatusRunProgram=Dovršavanje instalacije...
+StatusRestartingApplications=Ponovno pokretanje aplikacija...
+StatusRollback=Vraćanje izmena...
 
 ; *** Misc. errors
 ErrorInternal2=Unutrašnja greška: %1
-ErrorFunctionFailedNoCode=%1 neuspeh
-ErrorFunctionFailed=%1 neuspeh; kod %2
-ErrorFunctionFailedWithMessage=%1 neuspeh; kod %2.%n%3
+ErrorFunctionFailedNoCode=%1 nije uspelo
+ErrorFunctionFailed=%1 nije uspelo; kôd %2
+ErrorFunctionFailedWithMessage=%1 nije uspelo; kôd %2.%n%3
 ErrorExecutingProgram=Ne mogu da pokrenem datoteku:%n%1
 
 ; *** Registry errors
@@ -346,10 +348,10 @@ ErrorCopying=Došlo je do greške pri umnožavanju datoteke:
 ErrorDownloading=Došlo je do greške pri pokušaju preuzimanja datoteke:
 ErrorExtracting=Došlo je do greške pri pokušaju raspakivanja arhive:
 ErrorReplacingExistingFile=Došlo je do greške pri zameni postojeće datoteke:
-ErrorRestartReplace=Ne mogu da zamenim:
+ErrorRestartReplace=RestartReplace nije uspelo:
 ErrorRenamingTemp=Došlo je do greške pri preimenovanju datoteke u odredišnoj fascikli:
 ErrorRegisterServer=Ne mogu da upišem DLL/OCX: %1
-ErrorRegSvr32Failed=RegSvr32 nije uspeo. Greška %1
+ErrorRegSvr32Failed=RegSvr32 nije uspeo; izlazni kôd %1
 ErrorRegisterTypeLib=Ne mogu da upišem biblioteku tipova: %1
 
 ; *** Uninstall display name markings
@@ -363,30 +365,30 @@ UninstallDisplayNameMarkAllUsers=Svi korisnici
 UninstallDisplayNameMarkCurrentUser=Trenutni korisnik
 
 ; *** Post-installation errors
-ErrorOpeningReadme=Došlo je do greške pri otvaranju tekstualne datoteke.
+ErrorOpeningReadme=Došlo je do greške pri otvaranju datoteke README.
 ErrorRestartingComputer=Ne mogu ponovo da pokrenem računar. Uradite to sami.
 
 ; *** Uninstaller messages
 UninstallNotFound=Datoteka „%1“ ne postoji. Ne mogu da deinstaliram program.
 UninstallOpenError=Datoteka „%1“ ne može da se otvori. Ne mogu da deinstaliram program
-UninstallUnsupportedVer=Izveštaj „%1“ je u neprepoznatljivom formatu. Ne mogu da deinstaliram program
-UninstallUnknownEntry=Nepoznat unos (%1) se pojavio u izveštaju deinstalacije
-ConfirmUninstall=Želite li da deinstalirate %1 i sve njegove komponente?
-UninstallOnlyOnWin64=Program se može deinstalirati samo na 64-bitnom Windows-u.
-OnlyAdminCanUninstall=Program može deinstalirati samo korisnik s administratorskim pravima.
+UninstallUnsupportedVer=Datoteka evidencije deinstalacije „%1“ ima format koji ova verzija programa za deinstalaciju ne prepoznaje. Deinstalacija nije moguća
+UninstallUnknownEntry=U evidenciji deinstalacije pronađen je nepoznat unos (%1)
+ConfirmUninstall=Želite li da potpuno uklonite %1 i sve njegove komponente?
+UninstallOnlyOnWin64=Ova instalacija može da se deinstalira samo na 64-bitnom Windowsu.
+OnlyAdminCanUninstall=Ovu instalaciju može da deinstalira samo korisnik s administratorskim pravima.
 UninstallStatusLabel=Sačekajte da se %1 deinstalira sa računara.
-UninstalledAll=%1 je deinstaliran sa računara.
-UninstalledMost=%1 je deinstaliran.%n%nNeke komponente nisu mogle biti uklonjene. Možete ih obrisati ručno.
+UninstalledAll=%1 je uspešno uklonjen sa računara.
+UninstalledMost=Deinstalacija programa %1 je završena.%n%nNeke stavke nisu mogle da se uklone. Možete ih ukloniti ručno.
 UninstalledAndNeedsRestart=Da bi se završila deinstalacija programa %1, potrebno je ponovo pokrenuti računar.%n%nŽelite li da ga ponovo pokrenete?
 UninstallDataCorrupted=Datoteka „%1“ je oštećena. Ne mogu da deinstaliram program
 
 ; *** Uninstallation phase messages
-ConfirmDeleteSharedFileTitle=Brisanje deljene datoteke
-ConfirmDeleteSharedFile2=Sistem je prijavio da sledeću deljenu datoteku više ne koristi nijedan program. Želite li da je uklonite?%n%nAko nekim programima i dalje treba ova datoteka a ona je obrisana, ti programi možda neće ispravno raditi. Ako niste sigurni šta da radite, kliknite na „Ne“. Ostavljanje datoteke na disku neće prouzrokovati nikakvu štetu.
+ConfirmDeleteSharedFileTitle=Ukloniti deljenu datoteku?
+ConfirmDeleteSharedFile2=Sistem ukazuje na to da sledeću deljenu datoteku više ne koristi nijedan program. Želite li da je program za deinstalaciju ukloni?%n%nAko neki programi i dalje koriste ovu datoteku, a ona se ukloni, ti programi možda neće ispravno raditi. Ako niste sigurni, izaberite „Ne“. Ostavljanje datoteke na sistemu neće prouzrokovati nikakvu štetu.
 SharedFileNameLabel=Naziv datoteke:
-SharedFileLocationLabel=Putanja:
+SharedFileLocationLabel=Lokacija:
 WizardUninstalling=Stanje deinstalacije
-StatusUninstalling=Deinstaliram %1...
+StatusUninstalling=Deinstaliranje programa %1...
 
 ; *** Shutdown block reasons
 ShutdownBlockReasonInstallingApp=Instaliram %1.
@@ -398,14 +400,14 @@ ShutdownBlockReasonUninstallingApp=Deinstaliram %1.
 [CustomMessages]
 
 NameAndVersion=%1 verzija %2
-AdditionalIcons=Dodatne ikone:
-CreateDesktopIcon=&Postavi ikonu na radnu površinu
-CreateQuickLaunchIcon=P&ostavi ikonu na traku za brzo pokretanje
+AdditionalIcons=Dodatne prečice:
+CreateDesktopIcon=Napravi &prečicu na radnoj površini
+CreateQuickLaunchIcon=Napravi prečicu na traci za &brzo pokretanje
 ProgramOnTheWeb=%1 na internetu
 UninstallProgram=Deinstaliraj %1
 LaunchProgram=Pokreni %1
-AssocFileExtension=&Poveži %1 sa formatom %2
-AssocingFileExtension=Povezujem %1 sa formatom %2...
+AssocFileExtension=&Poveži %1 sa oznakom tipa datoteke %2
+AssocingFileExtension=Povezivanje programa %1 sa oznakom tipa datoteke %2...
 AutoStartProgramGroupDescription=Pokretanje:
 AutoStartProgram=Automatski pokreni %1
 AddonHostProgramNotFound=%1 se ne nalazi u navedenoj fascikli.%n%nŽelite li ipak da nastavite?


### PR DESCRIPTION
This PR performs a full review of the Serbian Latin translation for Inno Setup 6.5.0+.

Changes include:

* correcting grammar, punctuation and terminology;
* improving fidelity to the English source;
* restoring information such as “all”, “now”, “later” and “automatically” where it had been omitted;
* correcting the translation of `CompactInstallation`;
* preserving technical terms such as the Power Users group and `RestartReplace`;
* improving consistency across installation and uninstallation messages;
* preserving all keys, placeholders, line breaks and file structure.

The translation has also been technically validated against `Default.isl`:

* 296 matching entries;
* no missing, additional or duplicate keys;
* no placeholder errors;
* native language name preserved as `Srpski`.

I have contacted the maintainer listed in the file by email and asked for a native review of the proposed changes.

I will update this PR if I receive any corrections or confirmation.