### PR TITLE
Correct UniPs source metadata in SBOM

### DIFF
--- a/SBOM.spdx.json
+++ b/SBOM.spdx.json
@@ -129,8 +129,8 @@
       "copyrightText": "Copyright (C) 2000-2014 by Carlo Kok and RemObjects Software, LLC",
       "supplier": "Organization: RemObjects Software, LLC",
       "versionInfo": "NOASSERTION",
-      "comment": "Optional feature; tracked as a git submodule and required revision is recorded in the Inno Setup repo.",
-      "sourceInfo": "Submodule path Components/UniPs; revision is recorded via .gitmodules and the repo's submodule metadata."
+      "comment": "Optional feature; source is included in Components/UniPs and the required upstream revision is recorded in Components/UniPs/rev.txt.",
+      "sourceInfo": "Source path: Components/UniPs; upstream revision: Components/UniPs/rev.txt."
     },
     {
       "name": "LZMA SDK",


### PR DESCRIPTION
This pull request corrects the source metadata for RemObjects Pascal Script
under `Components/UniPs` in `SBOM.spdx.json`.

The component is currently described as a Git submodule whose revision is
recorded through `.gitmodules`. However, the repository does not contain a
`.gitmodules` file.

The UniPs sources are included directly under `Components/UniPs`, and the
upstream revision is recorded in `Components/UniPs/rev.txt`.

This change updates only the SBOM description and source information. It does
not change the component, its version, or any source code.

The resulting JSON has been validated successfully.