### PR TITLE
Fix wording in new documentation

### DIFF
--- a/ISHelp/isetup.xml
+++ b/ISHelp/isetup.xml
@@ -3981,7 +3981,7 @@ iside --new-script-wizard <i>&lt;wizard name&gt; &lt;script name&gt;</i></precod
 
 <ul>
 <li>The top-level temporary directory path is retrieved using the <tt>GetTempPath2</tt> API when available. This means that when running under the SYSTEM user account, subdirectories will be created under the private <tt>%SystemRoot%\SystemTemp</tt> directory instead of the shared <tt>%SystemRoot%\Temp</tt> directory. <tt>GetTempPath2</tt> was first introduced in Windows 11 and later backported to Windows 10 and Windows Server 2016. On older systems, <tt>GetTempPath</tt> is used instead.</li>
-<li>The names of the subdirectories include ten base-36 digits (0&ndash;9, A&ndash;Z), randomly generated using a cryptographically secure random number generator (CSPRNG).</li>
+<li>The names of the subdirectories include ten base-36 digits (0-9 and A-Z), randomly generated using a cryptographically secure random number generator (CSPRNG).</li>
 <li><p>When the top-level temporary directory path is <tt>%SystemRoot%\Temp</tt>, subdirectories are created with a special access control list (ACL) that contains "allow" entries for only the current user, the built-in Administrators group, and the SYSTEM user. This is necessary because the default ACL on <tt>%SystemRoot%\Temp</tt> allows all unprivileged users to create files inside subdirectories.</p>
 <p>The same ACL is used when the process is running elevated and the top-level temporary directory is on a local drive (any path), except the current user's access is set to "Read &amp; Execute" rather than "Full Control". Although Microsoft does not intend for elevation to define a security boundary, this is done as a defense-in-depth measure to prevent non-elevated processes running under the same user account from writing to the subdirectory.</p></li>
 </ul>
@@ -4043,7 +4043,7 @@ iside --new-script-wizard <i>&lt;wizard name&gt; &lt;script name&gt;</i></precod
 <ul>
 <li>Expired and self-signed certificates are never accepted.</li>
 <li>TLS 1.0 and TLS 1.1 are never accepted. Both TLS 1.2 and TLS 1.3 are supported.</li>
-<li>Downloaded files can be verified using SHA-256 hash or an <link topic="issig"><tt>.issig</tt> signature</link>. Using the latter has the benefit that your script does not need to be changed when the downloaded file or archive changes, so any installers built will also keep working (they are "evergreen").</li>
+<li>Downloaded files can be verified using a SHA-256 hash or an <link topic="issig"><tt>.issig</tt> signature</link>. Using the latter has the benefit that your script does not need to be changed when the downloaded file or archive changes, so any installers built will also keep working (they are "evergreen").</li>
 <li>Passwords in URLs are automatically excluded from Setup's log.</li>
 </ul>
 
@@ -4076,9 +4076,9 @@ iside --new-script-wizard <i>&lt;wizard name&gt; &lt;script name&gt;</i></precod
 <ul>
 <li>Releases are built on a dedicated machine only used for this purpose. Signing keys are not stored on other machines.</li>
 <li>The Inno Setup source code is self-contained and no external dependencies are pulled in when a release is built.</li>
-<li>Precompiled files included in Inno Setup's source code are code signed and are accompanied with <link topic="issig"><tt>.issig</tt> signature</link> files to detect corruption or tampering before using them to build a release.</li>
+<li>Precompiled files included in Inno Setup's source code are code signed and are accompanied by <link topic="issig"><tt>.issig</tt> signature</link> files to detect corruption or tampering before using them to build a release.</li>
 <li>Vendor updates of third-party source code (7-Zip, LZMA SDK, zlib, bzip2, Scintilla) are reviewed before being applied. An <extlink href="https://raw.githubusercontent.com/jrsoftware/issrc/refs/heads/main/SBOM.spdx.json">SPDX Software Bill of Materials</extlink> (SBOM) is available. Of the named sources, only LZMA SDK is an integral part of the Setup program, and only in a reduced form.</li>
-<li>Release binaries are made available through <extlink href="https://github.com/jrsoftware/issrc/releases">immutable GitHub releases</extlink> and accompanied with <link topic="issig"><tt>.issig</tt> signature</link> files you can use to detect corruption or tampering before running them. For more details, see <extlink href="https://jrsoftware.org/isdl-verify.php">Verifying Inno Setup Downloads</extlink>.</li>
+<li>Release binaries are made available through <extlink href="https://github.com/jrsoftware/issrc/releases">immutable GitHub releases</extlink> and accompanied by <link topic="issig"><tt>.issig</tt> signature</link> files you can use to detect corruption or tampering before running them. For more details, see <extlink href="https://jrsoftware.org/isdl-verify.php">Verifying Inno Setup Downloads</extlink>.</li>
 <li>Our GitHub repositories require signed commits on all branches, have GitHub Actions disabled, and do not allow any workflows to run.</li>
 </ul>
 

--- a/whatsnew.htm
+++ b/whatsnew.htm
@@ -63,11 +63,11 @@ For conditions of distribution and use, see <tt><a href="files/is/license.txt">L
   <ul>
     <li>Added new <i>Language</i> option to display the Compiler IDE in English (the default), German, Japanese, Czech, or Dutch.
     <ul>
-      <li>The translations cannot be edited, and additional languages are not being accepted. German, Japanese and Czech were chosen first because of the strong commercial support from their users, relative to the size of their communities. Thank you.</li>
+      <li>The translations cannot be edited, and additional languages are not being accepted. German, Japanese, and Czech were chosen first because of the strong commercial support from their users, relative to the size of their communities. Thank you.</li>
       <li>This applies to the Compiler IDE only. The command-line compiler (ISCC) and the compiler itself remain English.</li>
     </ul>
     </li>
-    <li>Added a new <i>RTF Editor</i> to the <i>Tools</i> menu for creating the RTF files Setup can display. It renders text exactly as Setup will, making it a small built-in replacement for the beloved WordPad that is no more.</li>
+    <li>Added a new <i>RTF Editor</i> to the <i>Tools</i> menu for creating the RTF files Setup can display. It renders text exactly as Setup will, making it a small built-in replacement for WordPad.</li>
     <li>Added new <i>Disable Output</i>, <i>Disable Compression</i>, <i>Disable Signing</i>, and <i>Disable Signcheck Validation</i> menu items to the <i>Build</i> menu. These are not remembered between sessions.</li>
     <li>Compiler errors are now also shown in the <i>Compiler Output</i> view, instead of only in a message box.</li>
     <li>The status bar now shows information about the current selection when text is selected, instead of only the caret position.</li>
@@ -92,9 +92,9 @@ For conditions of distribution and use, see <tt><a href="files/is/license.txt">L
     <li>Added new <tt>--preprocess</tt> (<tt>-e</tt>) option to preprocess to <tt>stdout</tt> and suppress compilation.</li>
     <li>Added new <tt>--messages-jsonl</tt> (<tt>-mj</tt>) option to output errors and warnings in JSONL format, making them easier to parse by tools and scripts. Warnings are not suppressed by <tt>--quiet</tt> when <tt>--messages-jsonl</tt> is active.</li>
     <li>Added new <tt>--version</tt> option to print the compiler engine version.</li>
-    <li>Improved the <tt>--quiet-progress</tt> (<tt>-qp</tt>) option, especially progress not updating when the screen is full in Windows Terminal.</li>
+    <li>Improved the <tt>--quiet-progress</tt> (<tt>-qp</tt>) option. Progress is now updated correctly when the screen is full in Windows Terminal.</li>
     <li>Warnings are now always written to <tt>stderr</tt> instead of <tt>stdout</tt>, consistent with other tools.</li>
-    <li><i>Fix:</i> ISPP option <tt>-$e</tt> (emit empty lines) now defaults to on, just like when compiling from the Compiler IDE and like the documentation said.</li>
+    <li><i>Fix:</i> ISPP option <tt>-$e</tt> (emit empty lines) now defaults to on, consistent with compilation from the Compiler IDE and with the documentation.</li>
     <li>Other minor fixes.</li>
   </ul>
   </li>


### PR DESCRIPTION
This pull request fixes a small set of objective wording and documentation-style issues in content added or updated for Inno Setup 7.0.2 and 7.1.0-dev.

Changes include:

- replacing an en dash range with the repository's required punctuation style;
- adding the missing article before `SHA-256 hash`;
- changing `accompanied with` to `accompanied by`;
- adding the required Oxford comma;
- removing colloquial wording from the WordPad description;
- clarifying two revision-history entries.

There are no source code or behavior changes.

Validation:

- `git diff --check` passes;
- `ISHelp/isetup.xml` parses successfully with its local DTD;
- the help build was not run (`-SkipHelpBuild` was used).
