### PR TITLE
Add Zstandard compression support

### DIFF
--- a/Projects/Bin/synch-isfiles.bat
+++ b/Projects/Bin/synch-isfiles.bat
@@ -14,6 +14,10 @@ copy ..\..\Files\isscint*.dll
 copy ..\..\Files\isscint*.dll.issig
 copy ..\..\Files\islzma*.dll
 copy ..\..\Files\islzma*.dll.issig
+copy ..\..\Files\isunzstd*.dll
+copy ..\..\Files\isunzstd*.dll.issig
+copy ..\..\Files\iszstd*.dll
+copy ..\..\Files\iszstd*.dll.issig
 copy ..\..\Files\islzma*.exe
 copy ..\..\Files\islzma*.exe.issig
 copy ..\..\Files\WizClassicSmallImage.bmp

--- a/Projects/ISCmplr.dpr
+++ b/Projects/ISCmplr.dpr
@@ -32,6 +32,7 @@ uses
   Compression.Zlib in 'Src\Compression.Zlib.pas',
   Compression.bzlib in 'Src\Compression.bzlib.pas',
   Compression.LZMACompressor in 'Src\Compression.LZMACompressor.pas',
+  Compression.Zstd in 'Src\Compression.Zstd.pas',
   Shared.FileClass in 'Src\Shared.FileClass.pas',
   ChaCha20 in '..\Components\ChaCha20.pas',
   Shared.VerInfoFunc in 'Src\Shared.VerInfoFunc.pas',

--- a/Projects/ISCmplr.dproj
+++ b/Projects/ISCmplr.dproj
@@ -134,6 +134,7 @@
         <DCCReference Include="Src\Compression.Zlib.pas"/>
         <DCCReference Include="Src\Compression.bzlib.pas"/>
         <DCCReference Include="Src\Compression.LZMACompressor.pas"/>
+        <DCCReference Include="Src\Compression.Zstd.pas"/>
         <DCCReference Include="Src\Shared.FileClass.pas"/>
         <DCCReference Include="..\Components\ChaCha20.pas"/>
         <DCCReference Include="Src\Shared.VerInfoFunc.pas"/>

--- a/Projects/Setup.dpr
+++ b/Projects/Setup.dpr
@@ -52,6 +52,7 @@ uses
   Compression.Zlib in 'Src\Compression.Zlib.pas',
   Compression.bzlib in 'Src\Compression.bzlib.pas',
   Compression.LZMADecompressor in 'Src\Compression.LZMADecompressor.pas',
+  Compression.Zstd in 'Src\Compression.Zstd.pas',
   Shared.FileClass in 'Src\Shared.FileClass.pas',
   MD5 in '..\Components\MD5.pas',
   MD5.Test in '..\Components\MD5.Test.pas',

--- a/Projects/Setup.dproj
+++ b/Projects/Setup.dproj
@@ -161,6 +161,7 @@
         <DCCReference Include="Src\Compression.Zlib.pas"/>
         <DCCReference Include="Src\Compression.bzlib.pas"/>
         <DCCReference Include="Src\Compression.LZMADecompressor.pas"/>
+        <DCCReference Include="Src\Compression.Zstd.pas"/>
         <DCCReference Include="Src\Shared.FileClass.pas"/>
         <DCCReference Include="..\Components\MD5.pas"/>
         <DCCReference Include="..\Components\MD5.Test.pas"/>

--- a/Projects/SetupCustomStyle.dpr
+++ b/Projects/SetupCustomStyle.dpr
@@ -52,6 +52,7 @@ uses
   Compression.Zlib in 'Src\Compression.Zlib.pas',
   Compression.bzlib in 'Src\Compression.bzlib.pas',
   Compression.LZMADecompressor in 'Src\Compression.LZMADecompressor.pas',
+  Compression.Zstd in 'Src\Compression.Zstd.pas',
   Shared.FileClass in 'Src\Shared.FileClass.pas',
   MD5 in '..\Components\MD5.pas',
   MD5.Test in '..\Components\MD5.Test.pas',

--- a/Projects/SetupCustomStyle.dproj
+++ b/Projects/SetupCustomStyle.dproj
@@ -162,6 +162,7 @@
         <DCCReference Include="Src\Compression.Zlib.pas"/>
         <DCCReference Include="Src\Compression.bzlib.pas"/>
         <DCCReference Include="Src\Compression.LZMADecompressor.pas"/>
+        <DCCReference Include="Src\Compression.Zstd.pas"/>
         <DCCReference Include="Src\Shared.FileClass.pas"/>
         <DCCReference Include="..\Components\MD5.pas"/>
         <DCCReference Include="..\Components\MD5.Test.pas"/>

--- a/Projects/Src/Compiler.HelperFunc.pas
+++ b/Projects/Src/Compiler.HelperFunc.pas
@@ -73,6 +73,9 @@ function IsValidIdentString(const S: String; AllowBackslash, AllowOperators: Boo
 procedure SkipWhitespace(var S: PChar);
 function ExtractWords(var S: PChar; const Sep: Char): String;
 function UnescapeBraces(const S: String): String;
+{$IFDEF WIN64}
+function IsArm64: Boolean;
+{$ENDIF}
 
 implementation
 
@@ -326,5 +329,36 @@ begin
       Inc(I);
   end;
 end;
+
+{$IFDEF WIN64}
+function IsArm64: Boolean;
+const
+  IMAGE_FILE_MACHINE_ARM64 = $AA64;
+  {$IFNDEF CPUX64}
+  PROCESSOR_ARCHITECTURE_ARM64 = 12;
+  {$ENDIF}
+var
+  IsWow64Process2Func: function(hProcess: THandle; var pProcessMachine, pNativeMachine: USHORT): BOOL; stdcall;
+begin
+  const KernelModule = GetModuleHandle(kernel32);
+
+  IsWow64Process2Func := GetProcAddress(KernelModule, 'IsWow64Process2');
+  var ProcessMachine, NativeMachine: USHORT;
+  if Assigned(IsWow64Process2Func) and
+      IsWow64Process2Func(GetCurrentProcess, ProcessMachine, NativeMachine) then
+    Exit(NativeMachine = IMAGE_FILE_MACHINE_ARM64);
+
+  { When running with x64 emulation on ARM64, GetNativeSystemInfo will just lie to us, so only
+    call if not x64 (which currently is impossible) }
+  {$IFNDEF CPUX64}
+  var SysInfo: TSystemInfo;
+  GetNativeSystemInfo(SysInfo);
+  if SysInfo.wProcessorArchitecture = PROCESSOR_ARCHITECTURE_ARM64 then
+    Exit(True);
+  {$ENDIF}
+
+  Result := False;
+end;
+{$ENDIF}
 
 end.

--- a/Projects/Src/Compiler.Messages.pas
+++ b/Projects/Src/Compiler.Messages.pas
@@ -114,6 +114,7 @@ const
   SCompilerArchitectureIdentifierDeprecatedWarning = 'Architecture identifier "%s" is deprecated. ' +
     'Substituting "%s", but note that "%s" is preferred in most cases. See the "Architecture Identifiers" topic in help file for more information.';
   SCompilerRegTypeLibArchitectureMismatch = '%d-bit Setup cannot register type libraries in the %d-bit registry view. If you intend for the type library to be registered in the %0:d-bit registry view, add the "%0:dbit" flag';
+  SCompilerZstdTooManyThreads = 'CompressionThreads should be set to a fixed number when using Zstd compression with SolidCompression=no. More than one thread may lead to poor compression speeds with small files.';
 
   { Signing }
   SCompilerSignatureNeeded = 'Signed uninstaller mode is enabled. Using ' +

--- a/Projects/Src/Compiler.SetupCompiler.pas
+++ b/Projects/Src/Compiler.SetupCompiler.pas
@@ -33,8 +33,8 @@ uses
   SimpleExpression, SHA256, ChaCha20, Shared.SetupTypes, Shared.CommonFunc,
   Shared.Struct, Shared.CompilerInt.Struct, Shared.PreprocInt, Shared.SetupMessageIDs,
   Shared.SetupSectionDirectives, Shared.VerInfoFunc, Shared.DebugStruct,
-  Compiler.ScriptCompiler, Compiler.StringLists, Compression.LZMACompressor,
-  Compiler.ExeUpdateFunc;
+  Compiler.ScriptCompiler, Compiler.StringLists, Compiler.ExeUpdateFunc,
+  Compression.LZMACompressor, Compression.Zstd;
 
 type
   EISCompileError = class(Exception);
@@ -74,7 +74,7 @@ type
 
   TCodeParameterKind = (cpkCheck, cpkDirectiveCheck, cpkInstall, cpkOnLog);
 
-  TPrecompiledFile = (pfSetup, pfSetupCustomStyle, pfSetupLdr, pfIs7z, pfIsbunzip, pfIsunzlib, pfIslzma);
+  TPrecompiledFile = (pfSetup, pfSetupCustomStyle, pfSetupLdr, pfIs7z, pfIsbunzip, pfIsunzlib, pfIslzma, pfIsunzstd);
   TPrecompiledFiles = set of TPrecompiledFile;
 
   TWizardImages = TObjectList<TCustomMemoryStream>;
@@ -246,6 +246,7 @@ type
     procedure InitLZMADLL;
     procedure InitPreprocessor;
     procedure InitZipDLL;
+    procedure InitZstdDLL;
     procedure PopulateLanguageEntryData;
     procedure ProcessMinVersionParameter(const ParamValue: TParamValue;
       var AMinVersion: TSetupVersionData);
@@ -374,7 +375,7 @@ type
   end;
 
 var
-  ZipInitialized, BzipInitialized, LZMAInitialized: Boolean;
+  ZipInitialized, BzipInitialized, LZMAInitialized, ZstdInitialized: Boolean;
   PreprocessorInitialized: Boolean;
   PreprocessScriptProc: TPreprocessScriptProc;
 
@@ -617,6 +618,34 @@ begin
   PreprocessorInitialized := True;
 end;
 
+procedure TSetupCompiler.InitZstdDLL;
+begin
+  if ZstdInitialized then
+    Exit;
+  var Filename: String;
+  {$IFDEF WIN64}
+  var DllName: String;
+  if IsArm64 then begin
+    { We can use an Arm64EC DLL from our x64 EXE, for better performance }
+    DllName := 'iszstd-Arm64EC.dll';
+    const Arm64Filename = CompilerDir + DllName;
+    if NewFileExists(Arm64Filename) then { Allow it to be deleted, for easy performance comparison }
+      Filename := Arm64Filename;
+  end;
+  if Filename = '' then begin
+    DllName := 'iszstd-x64.dll';
+    Filename := CompilerDir + DllName;
+  end;
+  {$ELSE}
+  const DllName = 'iszstd.dll';
+  Filename := CompilerDir + DllName;
+  {$ENDIF};
+  const M = LoadCompilerDLL(Filename, [ltloTrustAllOnDebug]);
+  if not ZstdInitCompressFunctions(M) then
+    AbortCompile('Failed to get address of functions in ' + DllName);
+  ZstdInitialized := True;
+end;
+
 procedure TSetupCompiler.InitZipDLL;
 begin
   if ZipInitialized then
@@ -642,40 +671,6 @@ begin
 end;
 
 procedure TSetupCompiler.InitLZMADLL;
-
-  {$IFDEF WIN64}
-  
-  function IsArm64: Boolean;
-  const
-    IMAGE_FILE_MACHINE_ARM64 = $AA64;
-    {$IFNDEF CPUX64}
-    PROCESSOR_ARCHITECTURE_ARM64 = 12;
-    {$ENDIF}
-  var
-    IsWow64Process2Func: function(hProcess: THandle; var pProcessMachine, pNativeMachine: USHORT): BOOL; stdcall;
-  begin
-    const KernelModule = GetModuleHandle(kernel32);
-
-    IsWow64Process2Func := GetProcAddress(KernelModule, 'IsWow64Process2');
-    var ProcessMachine, NativeMachine: USHORT;
-    if Assigned(IsWow64Process2Func) and
-       IsWow64Process2Func(GetCurrentProcess, ProcessMachine, NativeMachine) then
-      Exit(NativeMachine = IMAGE_FILE_MACHINE_ARM64);
-
-    { When running with x64 emulation on ARM64, GetNativeSystemInfo will just lie to us, so only
-      call if not x64 (which currently is impossible) }
-    {$IFNDEF CPUX64}
-    var SysInfo: TSystemInfo;
-    GetNativeSystemInfo(SysInfo);
-    if SysInfo.wProcessorArchitecture = PROCESSOR_ARCHITECTURE_ARM64 then
-      Exit(True);
-    {$ENDIF}
-
-    Result := False;
-  end;
-  
-  {$ENDIF}
-
 begin
   if LZMAInitialized then
     Exit;
@@ -2679,7 +2674,7 @@ var
   function StrToPrecompiledFiles(S: String): TPrecompiledFiles;
   const
     PrecompiledFiles: array of PChar = ['setup', 'setupcustomstyle', 'setupldr',
-      'is7z', 'isbunzip', 'isunzlib', 'islzma'];
+      'is7z', 'isbunzip', 'isunzlib', 'islzma', 'isunzstd'];
   begin
     Result := [];
     while True do
@@ -2693,6 +2688,7 @@ var
         4: Include(Result, pfIsbunzip);
         5: Include(Result, pfIsunzlib);
         6: Include(Result, pfIslzma);
+        7: Include(Result, pfIsunzstd);
       end;
   end;
 
@@ -2941,6 +2937,10 @@ begin
           CompressMethod := cmLZMA2;
           CompressLevel := clLZMAMax;
         end
+        else if Value = 'zstd' then begin
+          CompressMethod := cmZstd;
+          CompressLevel := 18;
+        end
         else if Copy(Value, 1, 4) = 'zip/' then begin
           I := StrToIntDef(Copy(Value, 5, Maxint), -1);
           if (I < 1) or (I > 9) then
@@ -2965,6 +2965,13 @@ begin
           if not LZMAGetLevel(Copy(Value, 7, Maxint), I) then
             Invalid;
           CompressMethod := cmLZMA2;
+          CompressLevel := I;
+        end
+        else if Copy(Value, 1, 5) = 'zstd/' then begin
+          I := StrToIntDef(Copy(Value, 6, Maxint), -1);
+          if (I < 1) or (I > 22) then
+            Invalid;
+          CompressMethod := cmZstd;
           CompressLevel := I;
         end
         else
@@ -7431,7 +7438,7 @@ var
       WriteWizardImages(WizardImagesDynamicDark, W, WizardImages);
       WriteWizardImages(WizardSmallImagesDynamicDark, W, WizardSmallImages);
       WriteWizardImages(WizardBackImagesDynamicDark, W, WizardBackImages);
-      if SetupHeader.CompressMethod in [cmZip, cmBzip] then
+      if SetupHeader.CompressMethod in [cmZip, cmBzip, cmZstd] then
         WriteStream(DecompressorDLL, W);
       if SevenZipDLL <> nil then
         WriteStream(SevenZipDLL, W);
@@ -7613,6 +7620,10 @@ var
             end;
           cmLZMA2: begin
               Result := TLZMA2Compressor;
+            end;
+          cmZstd: begin
+              InitZstdDLL;
+              Result := TZSTDCompressor;
             end;
         else
           AbortCompile('GetCompressorClass: Unknown CompressMethod');
@@ -8372,6 +8383,10 @@ begin
     CallIdleProc;
 
     { Verify settings set in [Setup] section }
+    if CompressMethod = cmZstd then begin
+      if (CompressProps.NumBlockThreads = 0) and (not UseSolidCompression) then
+        WarningsList.Add(SCompilerZstdTooManyThreads);
+    end;
     if SetupDirectiveLines[ssUseSetupLdr] = 0 then begin
       if SetupArchitecture = sa32bit then
         SetupLdrArchitecture := sla32bit
@@ -8982,6 +8997,12 @@ begin
           AddStatus(Format(SCompilerStatusReadingFile, [DllName]));
           DecompressorDLL := CreateMemoryStreamFromFile(CompilerDir + DllName,
             not(pfIsbunzip in DisablePrecompiledFileVerifications), OnCheckedTrust);
+        end;
+      cmZstd: begin
+          const DllName = Format('isunzstd%s.dll', [DllNameExtension]);
+          AddStatus(Format(SCompilerStatusReadingFile, [DllName]));
+          DecompressorDLL := CreateMemoryStreamFromFile(CompilerDir + DllName,
+            not(pfIsunzstd in DisablePrecompiledFileVerifications), OnCheckedTrust);
         end;
     end;
 

--- a/Projects/Src/Compression.Base.pas
+++ b/Projects/Src/Compression.Base.pas
@@ -22,6 +22,11 @@ type
   TCompressorProps = class
   end;
 
+  TThreadedCompressorProps = class(TCompressorProps)
+  public
+    NumBlockThreads: Integer;
+  end;
+
   TCompressorProgressProc = procedure(BytesProcessed: Cardinal) of object;
   TCompressorWriteProc = procedure(const Buffer; Count: Cardinal) of object;
   TCustomCompressorClass = class of TCustomCompressor;

--- a/Projects/Src/Compression.LZMACompressor.pas
+++ b/Projects/Src/Compression.LZMACompressor.pas
@@ -31,15 +31,14 @@ type
   TLZMASRes = type Integer;
   TLZMACompressorCustomWorker = class;
 
-  TLZMACompressorProps = class(TCompressorProps)
+  TLZMACompressorProps = class(TThreadedCompressorProps)
   public
     Algorithm: Integer;
     BlockSize: Integer;
     BTMode: Integer;
     DictionarySize: Cardinal;
-    NumBlockThreads: Integer;
-    NumFastBytes: Integer;
     NumThreads: Integer;
+    NumFastBytes: Integer;
     NumThreadGroups: Integer;
     WorkerProcessCheckTrust: Boolean;
     WorkerProcessOnCheckedTrust: TProc<Boolean>;

--- a/Projects/Src/Compression.Zstd.pas
+++ b/Projects/Src/Compression.Zstd.pas
@@ -1,0 +1,373 @@
+unit Compression.Zstd;
+
+{
+  Inno Setup
+  Copyright (C) 1997-2026 Jordan Russell
+  Portions by Martijn Laan
+  For conditions of distribution and use, see LICENSE.TXT.
+
+  Originally contributed by Amyspark <amy@amyspark.me>
+
+  Declarations for Zstandard functions & structures
+}
+
+interface
+
+uses
+  Windows, SysUtils, Compression.Base;
+
+function ZstdInitCompressFunctions(Module: HMODULE): Boolean;
+function ZstdInitDecompressFunctions(Module: HMODULE): Boolean;
+
+type
+  TZSTD_inBuffer = record
+    src: Pointer;        { start of input buffer }
+    size: NativeUInt;        { size of input buffer }
+    pos: NativeUInt;         { position where reading stopped. Will be updated. Necessarily 0 <= pos <= size }
+  end;
+
+  TZSTD_outBuffer = record
+    dst: Pointer;        { start of output buffer }
+    size: NativeUInt;        { size of output buffer }
+    pos: NativeUInt;         { position where writing stopped. Will be updated. Necessarily 0 <= pos <= size }
+  end;
+
+  TZSTD_frameProgression = record
+    ingested: UInt64;   { nb input bytes read and buffered }
+    consumed: UInt64;   { nb input bytes actually compressed }
+    produced: UInt64;   { nb of compressed bytes generated and buffered }
+    flushed: UInt64;    { nb of compressed bytes flushed : not provided; can be tracked from caller side }
+    currentJobID: Cardinal;         { MT only : latest started job nb }
+    nbActiveWorkers: Cardinal;      { MT only : nb of workers actively compressing at probe time }
+  end;
+
+  TZstdCompressor = class(TCustomCompressor)
+  private
+    FCompressionLevel: Integer;
+    FNumThreads: Integer;
+    FInitialized: Boolean;
+    FStrm: Pointer;
+    FOut: TZSTD_outBuffer;
+    FBuffer: array[0..$FFFFF] of Byte;
+    { Workaround for Zstd not resetting the frame progression until compress2
+      is called. Let's keep a good local copy }
+    FProgress: TZSTD_FrameProgression;
+    procedure EndCompress;
+    procedure FlushBuffer;
+    procedure InitCompress;
+  protected
+    procedure DoCompress(const Buffer; Count: Cardinal); override;
+    procedure DoFinish; override;
+  public
+    constructor Create(AWriteProc: TCompressorWriteProc;
+      AProgressProc: TCompressorProgressProc; CompressionLevel: Integer;
+      ACompressorProps: TCompressorProps); override;
+    destructor Destroy; override;
+  end;
+
+  TZstdDecompressor = class(TCustomDecompressor)
+  private
+    FInitialized: Boolean;
+    FStrm: Pointer;
+    FIn: TZSTD_inBuffer;
+    FReachedEnd: Boolean;
+    FBuffer: array[0..$FFFFF] of Byte;
+  public
+    constructor Create(AReadProc: TDecompressorReadProc); override;
+    destructor Destroy; override;
+    procedure DecompressInto(var Buffer; Count: Cardinal); override;
+    procedure Reset; override;
+  end;
+
+implementation
+
+const
+  SZstdDataError = 'zstd: Compressed data is corrupted';
+  SZstdInternalError = 'zstd: Internal error. Code %d';
+
+  ZSTD_e_continue = 0;
+  ZSTD_e_flush    = 1;
+  ZSTD_e_end      = 2;
+
+  ZSTD_c_nbWorkers        = 400;
+
+  ZSTD_reset_session_only = 1;
+
+var
+  ZSTD_createCStream: function: Pointer; stdcall;
+  ZSTD_initCStream: function (zcs: Pointer; compressionLevel: Integer): NativeUInt; stdcall;
+  ZSTD_CCtx_setParameter: function(cctx: Pointer; param: Cardinal; value: Integer): NativeUInt; stdcall;
+  ZSTD_compressStream2: function(cctx: Pointer; var output: TZSTD_outBuffer; var input: TZSTD_inBuffer; endOp: Cardinal): NativeUInt; stdcall;
+  ZSTD_freeCStream: function(zcs: Pointer): NativeUInt; stdcall;
+
+  ZSTD_createDStream: function(): Pointer; stdcall;
+  ZSTD_initDStream: function(zds: Pointer): NativeUInt; stdcall;
+  ZSTD_decompressStream: function(zds: Pointer; var output: TZSTD_outBuffer; var input: TZSTD_inBuffer): NativeUInt; stdcall;
+  ZSTD_freeDStream: function(zds: Pointer): NativeUInt; stdcall;
+
+  ZSTD_isError: function(res: NativeUInt): Cardinal; stdcall;
+  ZSTD_CCtx_reset: function(cctx: Pointer; reset: Cardinal): NativeUInt; stdcall;
+  ZSTD_getFrameProgression: function(cctx: Pointer): TZSTD_frameProgression; stdcall;
+
+function ZstdInitCompressFunctions(Module: HMODULE): Boolean;
+begin
+  ZSTD_createCStream := GetProcAddress(Module, 'ZSTD_createCStream');
+  ZSTD_CCtx_setParameter := GetProcAddress(Module, 'ZSTD_CCtx_setParameter');
+  ZSTD_initCStream := GetProcAddress(Module, 'ZSTD_initCStream');
+  ZSTD_compressStream2 := GetProcAddress(Module, 'ZSTD_compressStream2');
+  ZSTD_freeCStream := GetProcAddress(Module, 'ZSTD_freeCStream');
+  ZSTD_isError := GetProcAddress(Module, 'ZSTD_isError');
+  ZSTD_CCtx_reset := GetProcAddress(Module, 'ZSTD_CCtx_reset');
+  ZSTD_getFrameProgression := GetProcAddress(Module, 'ZSTD_getFrameProgression');
+  Result := Assigned(ZSTD_createCStream) and Assigned(ZSTD_CCtx_setParameter)
+    and Assigned(ZSTD_initCStream) and Assigned(ZSTD_compressStream2)
+    and Assigned(ZSTD_freeCStream) and Assigned(ZSTD_isError)
+    and Assigned(ZSTD_CCtx_reset) and Assigned(ZSTD_getFrameProgression);
+  if not Result then begin
+    ZSTD_createCStream := nil;
+    ZSTD_initCStream := nil;
+    ZSTD_CCtx_setParameter := nil;
+    ZSTD_compressStream2 := nil;
+    ZSTD_freeCStream := nil;
+    ZSTD_isError := nil;
+    ZSTD_CCtx_reset := nil;
+    ZSTD_getFrameProgression := nil;
+  end;
+end;
+
+function ZstdInitDecompressFunctions(Module: HMODULE): Boolean;
+begin
+  ZSTD_createDStream := GetProcAddress(Module, 'ZSTD_createDStream');
+  ZSTD_initDStream := GetProcAddress(Module, 'ZSTD_initDStream');
+  ZSTD_decompressStream := GetProcAddress(Module, 'ZSTD_decompressStream');
+  ZSTD_freeDStream := GetProcAddress(Module, 'ZSTD_freeDStream');
+  ZSTD_isError := GetProcAddress(Module, 'ZSTD_isError');
+  Result := Assigned(ZSTD_createDStream) and Assigned(ZSTD_initDStream) and
+    Assigned(ZSTD_decompressStream) and Assigned(ZSTD_freeDStream) and Assigned(ZSTD_isError);
+  if not Result then begin
+    ZSTD_createDStream := nil;
+    ZSTD_initDStream := nil;
+    ZSTD_decompressStream := nil;
+    ZSTD_freeDStream := nil;
+    ZSTD_isError := nil;
+  end;
+end;
+
+function Check(const Code: NativeUInt): Boolean;
+begin
+  if ZSTD_isError(Code) <> 0 then
+    raise ECompressInternalError.CreateFmt(SZstdInternalError, [Code]);
+  Result := True;
+end;
+
+{ TZstdCompressor }
+
+constructor TZstdCompressor.Create(AWriteProc: TCompressorWriteProc;
+  AProgressProc: TCompressorProgressProc; CompressionLevel: Integer;
+  ACompressorProps: TCompressorProps);
+var
+  GetActiveProcessorCountFunc: function(GroupNumber: WORD): WORD; stdcall;
+begin
+  inherited;
+  FCompressionLevel := CompressionLevel;
+  FNumThreads := 0;
+  if ACompressorProps is TThreadedCompressorProps then begin
+    const Props = (ACompressorProps as TThreadedCompressorProps);
+    if Props.NumBlockThreads <> 0 then
+      FNumThreads := Props.NumBlockThreads;
+  end;
+  if FNumThreads = 0 then begin
+    { Let's make Zstd use automatically all physical processors }
+    GetActiveProcessorCountFunc := GetProcAddress(GetModuleHandle(kernel32),
+      'GetActiveProcessorCount');
+    if Assigned(GetActiveProcessorCountFunc) then begin
+      const ActiveProcessorCount = GetActiveProcessorCountFunc(65535);
+      if ActiveProcessorCount > 1 then
+        FNumThreads := ActiveProcessorCount div 2;
+    end;
+  end;
+  InitCompress;
+end;
+
+destructor TZstdCompressor.Destroy;
+begin
+  { Unlike other destructors e.g. Zlib, this library is backed by a runtime
+    thread pool. For this reason the buffer needs to be as small as
+    possible (1 block == 128KB + overhead), so as to trigger the flush
+    ASAP, then every write afterwards is promptly discarded from memory.
+    This helps a lot with returning the control to the event loop, minimizing
+    the time the UI spends unresponsive. }
+  var FUnusedIn: TZSTD_inBuffer;
+  FillChar(FUnusedIn, SizeOf(FUnusedIn), 0);
+  FOut.pos := 0;
+  var OldCount := FProgress.consumed;
+  var Code: NativeUInt := 1;
+  if Assigned(ProgressProc) and (FProgress.consumed <> FProgress.ingested) then begin
+    While Code <> 0 do begin
+      Code := ZSTD_compressStream2(FStrm, FOut, FUnusedIn, ZSTD_e_flush);
+      Check(Code);
+      FProgress := ZSTD_getFrameProgression(FStrm);
+      const Actual = FProgress.consumed - OldCount;
+      ProgressProc(Actual);
+      OldCount := FProgress.consumed;
+      FOut.pos := 0;
+    end;
+  end;
+  EndCompress;
+  Check(ZSTD_freeCStream(FStrm));
+  inherited;
+end;
+
+procedure TZstdCompressor.InitCompress;
+begin
+  { Decoupling initialization from compression context creation allows
+    reusing the context for further compression operations. Also, in
+    multithreaded mode, it's pretty easy to OOM Delphi by using Zstd together
+    with SolidCompression=no, as Zstd allocates a thread pool per context }
+  if FStrm = nil then begin
+    FStrm := ZSTD_createCStream();
+    if FStrm = nil then
+      OutOfMemoryError;
+    Check(ZSTD_initCStream(FStrm, FCompressionLevel));
+    if FNumThreads > 1 then begin
+      const Code = ZSTD_CCtx_setParameter(FStrm, ZSTD_c_nbWorkers, FNumThreads);
+      if ZSTD_isError(Code) <> 0 then
+        Check(ZSTD_CCtx_setParameter(FStrm, ZSTD_c_nbWorkers, 1));
+    end;
+  end;
+  if not FInitialized then begin
+    FillChar(FProgress, SizeOf(FProgress), 0);
+    FillChar(FOut, SizeOf(FOut), 0);
+    FOut.dst := @FBuffer;
+    FOut.size := SizeOf(FBuffer);
+    FOut.pos := 0;
+    FInitialized := True;
+  end;
+end;
+
+procedure TZstdCompressor.EndCompress;
+begin
+  if FInitialized then begin
+    FInitialized := False;
+    { Only reset the compression state; the rest is reusable }
+    Check(ZSTD_CCtx_reset(FStrm, ZSTD_reset_session_only));
+  end;
+end;
+
+procedure TZstdCompressor.FlushBuffer;
+begin
+  if FOut.pos > 0 then begin
+    WriteProc(FBuffer, FOut.pos);
+    FOut.pos := 0;
+  end;
+end;
+
+procedure TZstdCompressor.DoCompress(const Buffer; Count: Cardinal);
+begin
+  InitCompress;
+  var LIn: TZSTD_inBuffer;
+  LIn.src := @Buffer;
+  LIn.size := Count;
+  LIn.pos := 0;
+  var OldCount := FProgress.consumed;
+  while LIn.pos < Count do begin
+    Check(ZSTD_compressStream2(FStrm, FOut, LIn, ZSTD_e_continue));
+    if FOut.pos = FOut.size then
+      FlushBuffer;
+    { Maximize responsiveness by tying ProgressProc to the actual data
+      ingested; especially helpful with compression levels >= 19 }
+    if Assigned(ProgressProc) then begin
+      FProgress := ZSTD_getFrameProgression(FStrm);
+      const Actual = FProgress.consumed - OldCount;
+      ProgressProc(Actual);
+      OldCount := FProgress.consumed;
+    end;
+  end;
+end;
+
+procedure TZstdCompressor.DoFinish;
+begin
+  var LIn: TZSTD_inBuffer;
+  InitCompress;
+  var LReachedEnd := False;
+  FillChar(LIn, SizeOf(LIn), 0);
+  var OldCount := FProgress.consumed;
+  while not LReachedEnd do begin
+    const Code = ZSTD_compressStream2(FStrm, FOut, LIn, ZSTD_e_end);
+    Check(Code);
+    FlushBuffer;
+    if Code = 0 then
+      LReachedEnd := True;
+    if Assigned(ProgressProc) then begin
+      FProgress := ZSTD_getFrameProgression(FStrm);
+      const Actual = FProgress.consumed - OldCount;
+      ProgressProc(Actual);
+      OldCount := FProgress.consumed;
+    end;
+  end;
+  EndCompress;
+end;
+
+{ TZstdDecompressor }
+
+constructor TZstdDecompressor.Create(AReadProc: TDecompressorReadProc);
+begin
+  inherited Create(AReadProc);
+  FStrm := ZSTD_createDStream();
+  if FStrm = nil then
+    OutOfMemoryError;
+  try
+    Reset;
+    FInitialized := True;
+  except
+    begin
+      Check(ZSTD_freeDStream(FStrm));
+      raise;
+    end;
+  end;
+end;
+
+destructor TZstdDecompressor.Destroy;
+begin
+  if FInitialized then begin
+    Check(ZSTD_freeDStream(FStrm));
+    FInitialized := False;
+  end;
+  inherited Destroy;
+end;
+
+procedure TZstdDecompressor.DecompressInto(var Buffer; Count: Cardinal);
+begin
+  var LOut: TZSTD_outBuffer;
+  LOut.dst := @Buffer;
+  LOut.size := Count;
+  LOut.pos := 0;
+  while LOut.pos < Count do begin
+    if FReachedEnd then  { unexpected EOF }
+      raise ECompressDataError.Create(SZstdDataError);
+    if FIn.pos = FIn.size then begin
+      FIn.src := @FBuffer;
+      FIn.size := ReadProc(FBuffer, SizeOf(FBuffer));
+      FIn.pos := 0;
+    end;
+    const OldInPos = FIn.pos;
+    const OldOutPos = LOut.pos;
+    const Code = ZSTD_decompressStream(FStrm, LOut, FIn);
+    if ZSTD_isError(Code) <> 0 then begin
+      raise ECompressDataError.Create(SZstdDataError);
+    end else if (FIn.pos = OldInPos) and (LOut.pos = OldOutPos) then begin
+      { Sanity check; no data consumed or compressed at all }
+      raise ECompressDataError.Create(SZstdDataError);
+    end else if Code = 0 then
+      FReachedEnd := True;
+  end;
+end;
+
+procedure TZstdDecompressor.Reset;
+begin
+  FillChar(FIn, SizeOf(FIn), 0);
+  Check(ZSTD_initDStream(FStrm));
+  FReachedEnd := False;
+end;
+
+end.

--- a/Projects/Src/IDE.ScintStylerInnoSetup.pas
+++ b/Projects/Src/IDE.ScintStylerInnoSetup.pas
@@ -2163,6 +2163,7 @@ end;
 
 type
   TZipLevel = 1..9;
+  TZstdLevel = 1..22;
 
 const
   LZMALevels: TArray<TScintRawString> = ['fast', 'normal', 'max', 'ultra', 'ultra64'];
@@ -2178,10 +2179,12 @@ function GetCompressionValues: TArray<TScintRawString>;
 const
   ZipAlgos: TArray<TScintRawString> = ['zip', 'bzip'];
   LZMAAlgos: TArray<TScintRawString> = ['lzma', 'lzma2'];
+  ZstdAlgo: String = 'zstd';
 begin
   SetLength(Result, 1 +
     Length(ZipAlgos) + Length(ZipAlgos) * (High(TZipLevel) - Low(TZipLevel) + 1) +
-    Length(LZMAAlgos) + Length(LZMAAlgos) * Length(LZMALevels));
+    Length(LZMAAlgos) + Length(LZMAAlgos) * Length(LZMALevels) +
+    1 + (High(TZstdLevel) - Low(TZstdLevel) + 1));
   var I := 0;
   SetResult(I, 'none');
   for var Algo in ZipAlgos do begin
@@ -2194,6 +2197,9 @@ begin
     for var Level in  LZMALevels do
       SetResult(I, TScintRawString(Algo + '/' + Level));
   end;
+  SetResult(I, TScintRawString(ZstdAlgo));
+  for var Level := Low(TZstdLevel) to High(TZstdLevel) do
+    SetResult(I, TScintRawString(ZstdAlgo + '/' + Level.ToString));
 end;
 
 initialization
@@ -2268,7 +2274,7 @@ initialization
     SSDV(ssArchiveExtraction, ['auto', 'basic', 'enhanced/nopassword', 'enhanced', 'full']),
     SSDV(ssCloseApplications, ['force', SYes, SNo]),
     SSDV(ssCompression, GetCompressionValues),
-    SSDV(ssDisablePrecompiledFileVerifications, ['setup', 'setupcustomstyle', 'setupldr', 'is7z', 'isbunzip', 'isunzlib', 'islzma']),
+    SSDV(ssDisablePrecompiledFileVerifications, ['setup', 'setupcustomstyle', 'setupldr', 'is7z', 'isbunzip', 'isunzlib', 'islzma', 'isunzstd']),
     SSDV(ssEncryption, ['full', SYes, SNo]),
     SSDV(ssInternalCompressLevel, ['none'] + LZMALevels), { We don't list 0 }
     SSDV(ssLanguageDetectionMethod, ['uilanguage', 'locale', 'none']),

--- a/Projects/Src/Setup.FileExtractor.pas
+++ b/Projects/Src/Setup.FileExtractor.pas
@@ -54,7 +54,7 @@ implementation
 uses
   PathFunc, Shared.CommonFunc, Setup.MainFunc, SetupLdrAndSetup.Messages,
   Shared.SetupMessageIDs, Setup.InstFunc, Compression.Zlib, Compression.bzlib,
-  Compression.LZMADecompressor, SHA256, Setup.LoggingFunc, Setup.NewDiskForm;
+  Compression.LZMADecompressor, Compression.Zstd, SHA256, Setup.LoggingFunc, Setup.NewDiskForm;
 
 var
   FFileExtractor: TFileExtractor;
@@ -63,7 +63,7 @@ function FileExtractor: TFileExtractor;
 const
   DecompClasses: array[TSetupCompressMethod] of TCustomDecompressorClass =
     (TStoredDecompressor, TZDecompressor, TBZDecompressor, TLZMA1Decompressor,
-     TLZMA2Decompressor);
+     TLZMA2Decompressor, TZstdDecompressor);
 begin
   if FFileExtractor = nil then
     FFileExtractor := TFileExtractor.Create(DecompClasses[SetupHeader.CompressMethod]);

--- a/Projects/Src/Setup.MainFunc.pas
+++ b/Projects/Src/Setup.MainFunc.pas
@@ -257,7 +257,7 @@ uses
   ChaCha20, ECDSA, ISSigFunc, NewCtrls, PathFunc, UnsignedFunc, FormBackgroundStyleHook, RichEditViewer,
   SetupLdrAndSetup.Messages, Shared.SetupMessageIDs, Setup.DownloadFileFunc, Setup.ExtractFileFunc,
   SetupLdrAndSetup.InstFunc, Setup.InstFunc, Setup.PathRedir, {$IFNDEF WIN64} Setup.RedirFunc, {$ENDIF}
-  Compression.Base, Compression.Zlib, Compression.bzlib, Compression.LZMADecompressor,
+  Compression.Base, Compression.Zstd, Compression.Zlib, Compression.bzlib, Compression.LZMADecompressor,
   Shared.SetupEntFunc, Shared.EncryptionFunc,  Setup.SelectLanguageForm,
   Setup.WizardForm, Setup.DebugClient, Shared.VerInfoFunc, Setup.FileExtractor,
   Shared.FileClass, Setup.LoggingFunc, StringScanner,
@@ -2860,6 +2860,9 @@ var
     if DecompressorDLLHandle = 0 then
       InternalError(Format('Failed to load DLL "%s"', [Filename]));
     case SetupHeader.CompressMethod of
+      cmZstd:
+        if not ZstdInitDecompressFunctions(DecompressorDLLHandle) then
+          InternalError('ZstdInitDecompressFunctions failed');
       cmZip:
         if not ZlibInitDecompressFunctions(DecompressorDLLHandle) then
           InternalError('ZlibInitDecompressFunctions failed');
@@ -3525,7 +3528,7 @@ begin
         ReadWizardImages(Reader, WizardBackImages, WantWizardImagesDynamicDark);
         { Decompressor DLL }
         DecompressorDLL := nil;
-        if SetupHeader.CompressMethod in [cmZip, cmBzip] then begin
+        if SetupHeader.CompressMethod in [cmZip, cmBzip, cmZstd] then begin
           DecompressorDLL := TMemoryStream.Create;
           ReadFileIntoStream(Reader, DecompressorDLL);
         end;
@@ -3637,7 +3640,7 @@ begin
   CreateTempInstallDir;
 
   { Save DecompressorDLL stream as "_isdecmp.dll" in TempInstallDir, and load it }
-  if SetupHeader.CompressMethod in [cmZip, cmBzip] then
+  if SetupHeader.CompressMethod in [cmZip, cmBzip, cmZstd] then
     LoadDecompressorDLL;
 
   { Save SevenZipDll stream as "_is7z.dll" in TempInstallDir, and load it }

--- a/Projects/Src/Shared.Struct.pas
+++ b/Projects/Src/Shared.Struct.pas
@@ -33,7 +33,7 @@ const
     this file it's recommended you change SetupID. Any change will do (like
     changing the letters or numbers), as long as your format is
     unrecognizable by the standard Inno Setup. }
-  SetupID: TSetupID = 'Inno Setup Setup Data (7.0.0.3)';
+  SetupID: TSetupID = 'Inno Setup Setup Data (7.1.0)';
   UninstallLogID: array[Boolean] of TUninstallLogID =
     ('Inno Setup Uninstall Log (b)',
      'Inno Setup Uninstall Log (b) 64-bit'); { '64-bit' refers to 64-bit install mode }
@@ -81,7 +81,7 @@ type
       64-bit builds, even without specifying packed. But to be sure we specify
       it anyway. }
   TSetupLanguageDetectionMethod = (ldUILanguage, ldLocale, ldNone);
-  TSetupCompressMethod = (cmStored, cmZip, cmBzip, cmLZMA, cmLZMA2);
+  TSetupCompressMethod = (cmStored, cmZip, cmBzip, cmLZMA, cmLZMA2, cmZstd);
   TSetupKDFSalt = array[0..15] of Byte;
   TSetupEncryptionKey = array[0..31] of Byte;
   TSetupEncryptionNonce = record


### PR DESCRIPTION
hi! 

Following up on earlier inquiries on the mailing thread, I'm filing this proposal to add Zstd support to Inno's installer payload. 

My use case is to improve the performance of solid compressed installers; in my local testing (~600MB payload, comprising some 5GB worth of headers/DLLs/PDBs) I got a 2x speedup when skipping payloads, from 56s (with `lzma2/max`) to 24s (with `zstd/18`). With non-solid payloads the improvements are much more nuanced, from 22s down to 19s. 

The other benefit that libzstd brings is to use automatically managed multithreaded compression, without the need for glue code; this is especially useful for my use case since I rely on high compression levels. In this case, each compression call will cause data to be ingested automatically, and require the IS compiler to wait and write the payload on `TZstdCompressor.DoFinish` as it becomes available.

The new `Zstd` unit and associated glue code is based on the `Compiler.Zlib` implementation, with levels ranging from 1 to 22 (default = 0, which is managed by libzstd). Since I could not pass a number of worker threads (more on that below),  I hodge podged autodetected thread count detection, which I set to half the number of processors.

TODO / Questions / Need for improvement
--

- Would it be possible to subclass `TCompressorProps` so as to allow Zstd-specific parameters to be passed? There does is support, see https://github.com/jrsoftware/issrc/blob/67ccc36c179d4be50e6775c1d757d0705d5b18a3/Projects/Src/Compression.LZMACompressor.pas#L914-L916 but https://github.com/jrsoftware/issrc/blob/67ccc36c179d4be50e6775c1d757d0705d5b18a3/Projects/Src/Compiler.SetupCompiler.pas#L7800-L7801 there is no provision for using a different Props class.

- Related to the earlier, would it be possible to pin the number of threads when `UseSolidCompression=yes` to 2? I think this is also done for LZMA(2) but can't say for sure. When not using solid compression, there is no point in using multiple threads as compression is done asynchronously; and in my use case, with very small (usually less than 5MB) files.

Thanks for your feedback!